### PR TITLE
Respect Retry-After header

### DIFF
--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -203,9 +203,9 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 
             // Only retry if one of these codes is returned:
             // 429 - Too many requests;
-            // 503 - Service unavailable.
+            // 5xx - Server errors.
             NSInteger statusCode = response.HTTPResponse.statusCode;
-            if (statusCode == 429 || statusCode >= 500) {
+            if (statusCode == 429 || (statusCode >= 500 && statusCode < 600)) {
               // Move the events back to the main storage to be uploaded on the next attempt.
               return [storage removeBatchWithID:batchID deleteEvents:NO];
             } else {

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -334,19 +334,6 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
     return NO;
   }
 
-  // Upload events when there are with no additional conditions for kGDTCORTargetCSH.
-  if (target == kGDTCORTargetCSH) {
-    GDTCORLogDebug(@"%@", @"CCT: kGDTCORTargetCSH events are allowed to be "
-                          @"uploaded straight away.");
-    return YES;
-  }
-
-  if (target == kGDTCORTargetINT) {
-    GDTCORLogDebug(@"%@", @"CCT: kGDTCORTargetINT events are allowed to be "
-                          @"uploaded straight away.");
-    return YES;
-  }
-
   // Upload events with no additional conditions if high priority.
   if ((conditions & GDTCORUploadConditionHighPriority) == GDTCORUploadConditionHighPriority) {
     GDTCORLogDebug(@"%@", @"CCT: a high priority event is allowing an upload");

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -173,11 +173,13 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
               ^id(id result) {
                 // 7. Finish operation.
                 [self finishOperation];
+                backgroundTaskCompletion();
                 return nil;
               })
       .catchOn(self.uploaderQueue, ^(NSError *error) {
         // TODO: Maybe report the error to the client.
         [self finishOperation];
+        backgroundTaskCompletion();
       });
 }
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -283,7 +283,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
       NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
       formatter.numberStyle = NSNumberFormatterDecimalStyle;
       NSNumber *retryAfterSeconds = [formatter numberFromString:retryAfterHeader];
-      if (retryAfterSeconds) {
+      if (retryAfterSeconds != nil) {
         uint64_t retryAfterMillis = retryAfterSeconds.unsignedIntegerValue * 1000u;
         futureUploadTime = [GDTCORClock clockSnapshotInTheFuture:retryAfterMillis];
       }

--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
@@ -76,6 +76,7 @@
     for (GDTCOREvent *batchedEvent in _batches[batchID]) {
       _storedEvents[batchedEvent.eventID] = batchedEvent;
     }
+    [_batches removeObjectForKey:batchID];
     [self.removeBatchWithoutDeletingEventsExpectation fulfill];
   }
 

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -484,7 +484,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
   [self waitForUploadOperationsToFinish:self.uploader];
 }
 
-- (void)testUploadTarget_WhenBeforeServerNextUploadTimeForCCTAndFLLTargets_ThenDoNotUpload {
+- (void)testUploadTarget_WhenBeforeServerNextUploadTime_ThenDoNotUpload {
   [self assertUploadTargetRespectsNextRequestWaitTime:60
                                        waitTimeSource:GDTNextRequestWaitTimeSourceResponseBody
                                             forTarget:kGDTCORTargetCCT
@@ -508,6 +508,22 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
                                            conditions:GDTCORUploadConditionWifiData
                          shouldWaitForNextRequestTime:NO
                                         expectRequest:NO];
+
+  [self assertUploadTargetRespectsNextRequestWaitTime:60
+                                       waitTimeSource:GDTNextRequestWaitTimeSourceResponseBody
+                                            forTarget:kGDTCORTargetCSH
+                                                  QoS:GDTCOREventQosDefault
+                                           conditions:GDTCORUploadConditionWifiData
+                         shouldWaitForNextRequestTime:NO
+                                        expectRequest:NO];
+
+  [self assertUploadTargetRespectsNextRequestWaitTime:60
+                                       waitTimeSource:GDTNextRequestWaitTimeSourceResponseBody
+                                            forTarget:kGDTCORTargetINT
+                                                  QoS:GDTCOREventQosDefault
+                                           conditions:GDTCORUploadConditionWifiData
+                         shouldWaitForNextRequestTime:NO
+                                        expectRequest:NO];
 }
 
 - (void)
@@ -525,24 +541,6 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
                                             forTarget:kGDTCORTargetFLL
                                                   QoS:GDTCOREventQosDefault
                                            conditions:GDTCORUploadConditionHighPriority
-                         shouldWaitForNextRequestTime:NO
-                                        expectRequest:YES];
-}
-
-- (void)testUploadTarget_WhenBeforeServerNextUploadTimeForOtherTargets_ThenUpload {
-  [self assertUploadTargetRespectsNextRequestWaitTime:60
-                                       waitTimeSource:GDTNextRequestWaitTimeSourceResponseBody
-                                            forTarget:kGDTCORTargetCSH
-                                                  QoS:GDTCOREventQosDefault
-                                           conditions:GDTCORUploadConditionWifiData
-                         shouldWaitForNextRequestTime:NO
-                                        expectRequest:YES];
-
-  [self assertUploadTargetRespectsNextRequestWaitTime:60
-                                       waitTimeSource:GDTNextRequestWaitTimeSourceResponseBody
-                                            forTarget:kGDTCORTargetINT
-                                                  QoS:GDTCOREventQosDefault
-                                           conditions:GDTCORUploadConditionWifiData
                          shouldWaitForNextRequestTime:NO
                                         expectRequest:YES];
 }

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -279,7 +279,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
 
 - (void)testUploadTargetAfterFailure {
   // Set wait for next request time to 0.
-  __auto_type retryAfterHeaders = @{ @"Retry-After" : @"0" };
+  __auto_type retryAfterHeaders = @{@"Retry-After" : @"0"};
   [self sendEventFailureWithStatusCode:503 headers:retryAfterHeaders expectEventsToBeRemoved:NO];
   [self sendEventSuccessfully];
 }
@@ -622,11 +622,15 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
   return responseSentExpectation;
 }
 
-- (XCTestExpectation *)expectationTestServerResponseWithCode:(NSInteger)statusCode headers:(NSDictionary<NSString *, NSString *> *)headers {
+- (XCTestExpectation *)
+    expectationTestServerResponseWithCode:(NSInteger)statusCode
+                                  headers:(NSDictionary<NSString *, NSString *> *)headers {
   __weak __auto_type weakSelf = self;
   XCTestExpectation *responseSentExpectation = [self expectationWithDescription:@"response sent"];
 
-  self.testServer.requestHandler = ^(GCDWebServerDataRequest * _Nonnull request, GCDWebServerResponse * _Nullable suggestedResponse, GCDWebServerCompletionBlock  _Nonnull completionBlock) {
+  self.testServer.requestHandler = ^(GCDWebServerDataRequest *_Nonnull request,
+                                     GCDWebServerResponse *_Nullable suggestedResponse,
+                                     GCDWebServerCompletionBlock _Nonnull completionBlock) {
     // Redefining the self var addresses strong self capturing in the XCTAssert macros.
     __auto_type self = weakSelf;
     XCTAssertNotNil(self);
@@ -634,7 +638,8 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     weakSelf.testServer.requestHandler = nil;
 
     GCDWebServerResponse *response = [GCDWebServerResponse responseWithStatusCode:statusCode];
-    [headers enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull header, id  _Nonnull value, BOOL * _Nonnull stop) {
+    [headers enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull header, id _Nonnull value,
+                                                 BOOL *_Nonnull stop) {
       [response setValue:value forAdditionalHeader:header];
     }];
 
@@ -719,15 +724,15 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
       [self expectStorageHasEventsForTarget:self.generator.target result:YES];
 
   // 1.4. Expect a batch to be uploaded.
-  XCTestExpectation *responseSentExpectation = [self expectationTestServerResponseWithCode:statusCode headers:headers];
+  XCTestExpectation *responseSentExpectation =
+      [self expectationTestServerResponseWithCode:statusCode headers:headers];
 
   // 2. Create uploader and start upload.
   [self.uploader uploadTarget:self.generator.target withConditions:GDTCORUploadConditionWifiData];
 
   // 3. Wait for operations to complete in the specified order.
   [self waitForExpectations:@[
-    self.testStorage.batchIDsForTargetExpectation,
-    hasEventsExpectation,
+    self.testStorage.batchIDsForTargetExpectation, hasEventsExpectation,
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchWithoutDeletingEventsExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
@@ -751,7 +756,8 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
   XCTestExpectation *hasEventsExpectation =
       [self expectStorageHasEventsForTarget:self.generator.target result:YES];
 
-  // 1.3. Don't expect removing the batch keeping the events. Expect events to be removed with the batch instead.
+  // 1.3. Don't expect removing the batch keeping the events. Expect events to be removed with the
+  // batch instead.
   self.testStorage.removeBatchWithoutDeletingEventsExpectation.inverted = YES;
 
   // 1.4. Expect a batch to be uploaded.
@@ -781,7 +787,6 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
                                            conditions:(GDTCORUploadConditions)conditions
                          shouldWaitForNextRequestTime:(BOOL)shouldWaitForNextRequestTime
                                         expectRequest:(BOOL)expectRequest {
-
   // 0.1. Use a target that should respect next upload time.
   self.generator = [[GDTCCTEventGenerator alloc] initWithTarget:target];
   // 0.2. Register storage for the target.
@@ -797,7 +802,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
 
     case GDTNextRequestWaitTimeSourceRetryAfterHeader:
       [self sendEventFailureWithStatusCode:503
-                                   headers:@{ @"Retry-After" : @(nextRequestWaitTime).stringValue }
+                                   headers:@{@"Retry-After" : @(nextRequestWaitTime).stringValue}
                    expectEventsToBeRemoved:NO];
       break;
   }
@@ -836,8 +841,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
 
   // 3. Wait for expectations.
   [self waitForExpectations:@[
-    self.testStorage.batchIDsForTargetExpectation,
-    hasEventsExpectation2,
+    self.testStorage.batchIDsForTargetExpectation, hasEventsExpectation2,
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation,
     self.testStorage.removeBatchWithoutDeletingEventsExpectation

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -114,7 +114,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:YES];
 
   // 4. Wait for upload operation to finish.
@@ -149,7 +149,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:NO];
 
   // 4. Wait for upload operation to finish.
@@ -220,7 +220,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.removeBatchWithoutDeletingEventsExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3];
+                    timeout:1];
 
   // 1.4. Wait for 1st upload finish.
   requestCompletionBlock();
@@ -250,7 +250,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:YES];
 
   // 3.4. Wait for upload operation to finish.
@@ -314,7 +314,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:YES];
 
   // 1.4. Wait for upload operation to finish.
@@ -353,7 +353,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation1,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:YES];
 
   // 1.4. Wait for upload operation to finish.
@@ -386,7 +386,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:YES];
 
   // 2.4. Wait for upload operation to finish.
@@ -478,7 +478,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.removeBatchWithoutDeletingEventsExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3];
+                    timeout:1];
 
   // 4. Wait for 1st upload finish.
   [self waitForUploadOperationsToFinish:self.uploader];
@@ -771,7 +771,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.batchWithEventSelectorExpectation, responseSentExpectation,
     self.testStorage.removeBatchAndDeleteEventsExpectation
   ]
-                    timeout:3
+                    timeout:1
                enforceOrder:YES];
 
   // 4. Wait for upload operation to finish.
@@ -844,7 +844,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
     self.testStorage.removeBatchAndDeleteEventsExpectation,
     self.testStorage.removeBatchWithoutDeletingEventsExpectation
   ]
-                    timeout:3];
+                    timeout:1];
 
   // 4. Wait for 1st upload finish.
   [self waitForUploadOperationsToFinish:self.uploader];

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -281,7 +281,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
   // Set wait for next request time to 0.
   __auto_type retryAfterHeaders = @{ @"Retry-After" : @"0" };
   [self sendEventFailureWithStatusCode:503 headers:retryAfterHeaders expectEventsToBeRemoved:NO];
-  [self sendEventSuccessfullyExpectingOldBatchToBeRemoved:YES];
+  [self sendEventSuccessfully];
 }
 
 - (void)testUploadTarget_WhenThereAreBothStoredBatchAndEvents_ThenRemoveBatchAndBatchThenAllEvents {
@@ -739,7 +739,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
   [self waitForUploadOperationsToFinish:self.uploader];
 }
 
-- (void)sendEventSuccessfullyExpectingOldBatchToBeRemoved:(BOOL)expectOldBatchRemove {
+- (void)sendEventSuccessfully {
   // 0. Generate test events.
   [self.generator generateEvent:GDTCOREventQoSFast];
 
@@ -752,7 +752,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
       [self expectStorageHasEventsForTarget:self.generator.target result:YES];
 
   // 1.3. Don't expect removing the batch keeping the events. Expect events to be removed with the batch instead.
-  self.testStorage.removeBatchWithoutDeletingEventsExpectation.inverted = !expectOldBatchRemove;
+  self.testStorage.removeBatchWithoutDeletingEventsExpectation.inverted = YES;
 
   // 1.4. Expect a batch to be uploaded.
   XCTestExpectation *responseSentExpectation = [self expectationTestServerSuccessRequestResponse];
@@ -792,7 +792,7 @@ typedef NS_ENUM(NSInteger, GDTNextRequestWaitTimeSource) {
   self.testServer.responseNextRequestWaitTime = nextRequestWaitTime;
   switch (waitTimeSource) {
     case GDTNextRequestWaitTimeSourceResponseBody:
-      [self sendEventSuccessfullyExpectingOldBatchToBeRemoved:NO];
+      [self sendEventSuccessfully];
       break;
 
     case GDTNextRequestWaitTimeSourceRetryAfterHeader:

--- a/GoogleDataTransport/generate_project.sh
+++ b/GoogleDataTransport/generate_project.sh
@@ -29,6 +29,6 @@ echo $platform
 
 readonly DIR="$(git rev-parse --show-toplevel)"
 
-# "$DIR/GoogleDataTransport/ProtoSupport/generate_cct_protos.sh" || echo "Something went wrong generating protos.";
+"$DIR/GoogleDataTransport/ProtoSupport/generate_cct_protos.sh" || echo "Something went wrong generating protos.";
 
-pod gen "$DIR/GoogleDataTransport.podspec" --auto-open --local-sources=./ --gen-directory="$DIR/gen" --platforms=${platform} # --clean
+pod gen "$DIR/GoogleDataTransport.podspec" --auto-open --local-sources=./ --gen-directory="$DIR/gen" --platforms=${platform} --clean

--- a/GoogleDataTransport/generate_project.sh
+++ b/GoogleDataTransport/generate_project.sh
@@ -29,6 +29,6 @@ echo $platform
 
 readonly DIR="$(git rev-parse --show-toplevel)"
 
-"$DIR/GoogleDataTransport/ProtoSupport/generate_cct_protos.sh" || echo "Something went wrong generating protos.";
+# "$DIR/GoogleDataTransport/ProtoSupport/generate_cct_protos.sh" || echo "Something went wrong generating protos.";
 
-pod gen "$DIR/GoogleDataTransport.podspec" --auto-open --local-sources=./ --gen-directory="$DIR/gen" --platforms=${platform} --clean
+pod gen "$DIR/GoogleDataTransport.podspec" --auto-open --local-sources=./ --gen-directory="$DIR/gen" --platforms=${platform} # --clean


### PR DESCRIPTION
- b/171573251: respect Retry-After header
- fix background task completion
- don't remove events for all 5xx server responses, not only for 503