### PR TITLE
Fix diagnostics warnings

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '8.3.0'
+  s.version          = '8.3.1'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -58,6 +58,7 @@ Shared library for iOS SDK data transport needs.
   }.merge(header_search_paths)
 
   common_test_sources = ['GoogleDataTransport/GDTCORTests/Common/**/*.{h,m}']
+  common_cct_test_sources = ['GoogleDataTransport/GDTCCTTests/Common/**/*.{h,m}']
 
   # Test app specs
   if ENV['GDT_DEV'] && ENV['GDT_DEV'] == '1' then
@@ -92,7 +93,7 @@ Shared library for iOS SDK data transport needs.
     test_spec.scheme = { :code_coverage => true }
     test_spec.platforms = {:ios => ios_deployment_target, :osx => osx_deployment_target, :tvos => tvos_deployment_target}
     test_spec.requires_app_host = false
-    test_spec.source_files = ['GoogleDataTransport/GDTCORTests/Unit/**/*.{h,m}'] + common_test_sources
+    test_spec.source_files = ['GoogleDataTransport/GDTCORTests/Unit/**/*.{h,m}'] + common_test_sources + common_cct_test_sources
     test_spec.pod_target_xcconfig = header_search_paths
   end
 
@@ -145,8 +146,6 @@ Shared library for iOS SDK data transport needs.
       }
     end
   end
-
-  common_cct_test_sources = ['GoogleDataTransport/GDTCCTTests/Common/**/*.{h,m}']
 
   # Test specs
   s.test_spec 'CCT-Tests-Unit' do |test_spec|

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.3.1
+- Fix thread sanitizer and undefined behavior diagnostics warnings. ( https://github.com/firebase/firebase-ios-sdk/issues/7771)
+- URLSession delegate retain cycle. (https://github.com/firebase/firebase-ios-sdk/issues/7780)
 # v8.3.0
 - Upload logic was refactored to use [Promises library](https://github.com/google/promises) to improve readability and maintainability of the async code.
 - Fix some race conditions and edge cases when multiple targets have events ready for upload.

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -534,9 +534,9 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 }
 
 - (void)cancel {
-  [super cancel];
-
   @synchronized(self) {
+    [super cancel];
+
     // If the operation hasn't been started we can set `isFinished = YES` straight away.
     if (!_executing) {
       _executing = NO;

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -70,8 +70,8 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 @property(nonatomic, readonly) id<GDTCCTUploadMetadataProvider> metadataProvider;
 
 /// NSOperation state properties implementation.
-@property(nonatomic, readwrite, getter=executing) BOOL executing;
-@property(nonatomic, readwrite, getter=finished) BOOL finished;
+@property(nonatomic, readwrite, getter=isExecuting) BOOL executing;
+@property(nonatomic, readwrite, getter=isFinished) BOOL finished;
 
 @property(nonatomic, readwrite) BOOL uploadAttempted;
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
@@ -130,6 +130,10 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                                 options:0
                                                                   error:&error];
       NSString *base64Data = bytesDict[GDTCCTNetworkConnectionInfo];
+      if (base64Data == nil) {
+        return nil;
+      }
+
       NSData *networkConnectionInfoData = [[NSData alloc] initWithBase64EncodedString:base64Data
                                                                               options:0];
       if (error) {

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param storage A storage object to fetch events for upload.
  *  @param metadataProvider An object to retrieve/update data shared between different upload
  * operations.
+ *  @return An instance of GDTCCTUploadOperation ready to be added to an NSOperationQueue.
  */
 - (instancetype)initWithTarget:(GDTCORTarget)target
                     conditions:(GDTCORUploadConditions)conditions

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
@@ -68,9 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** The queue on which all CCT uploading will occur. */
 @property(nonatomic, readonly) dispatch_queue_t uploaderQueue;
 
-/** The URL session that will attempt upload. */
-@property(nonatomic, readonly) NSURLSession *uploaderSession;
-
 /** The current upload task. */
 @property(nullable, nonatomic, readonly) NSURLSessionUploadTask *currentTask;
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage+Promises.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage+Promises.m
@@ -58,7 +58,11 @@
                                        deleteEvents:(BOOL)deleteEvents {
   return
       [self batchIDsForTarget:target].thenOn(self.storageQueue, ^id(NSSet<NSNumber *> *batchIDs) {
-        return [self removeBatchesWithIDs:batchIDs deleteEvents:NO];
+        if (batchIDs.count == 0) {
+          return [FBLPromise resolvedWith:[NSNull null]];
+        } else {
+          return [self removeBatchesWithIDs:batchIDs deleteEvents:NO];
+        }
       });
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
@@ -125,7 +125,7 @@ typedef void (^GDTCORStorageBatchBlock)(NSNumber *_Nullable newBatchID,
 
 // TODO: Consider complete replacing block based API by promise API.
 
-/** Promise based version of API defined in  GDTCORStorageProtocol. See API docs for corresponding
+/** Promise based version of API defined in GDTCORStorageProtocol. See API docs for corresponding
  * methods in GDTCORStorageProtocol. */
 @protocol GDTCORStoragePromiseProtocol <GDTCORStorageProtocol>
 


### PR DESCRIPTION
- Fix https://github.com/firebase/firebase-ios-sdk/issues/7771 (TSAN and undefined behavior diagnostics warnings)
- fix `-[GDTCORUploadCoordinator TesttestThatAFailedUploadResultsInAnEventualRetry]` tests
- Fix https://github.com/firebase/firebase-ios-sdk/issues/7780 (URLSession delegate retain cycle)
- fix comment (from #3)

Enabling diagnostics on CI will be implemented in the following PRs, related draft: https://github.com/firebase/firebase-ios-sdk/pull/7778