### PR TITLE
Rename transform: API to transformGDTEvent:

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '8.4.0'
+  s.version          = '9.0.0'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransformer.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransformer.m
@@ -78,16 +78,16 @@
   dispatch_async(_eventWritingQueue, ^{
     GDTCOREvent *transformedEvent = event;
     for (id<GDTCOREventTransformer> transformer in transformers) {
-      if ([transformer respondsToSelector:@selector(transform:)]) {
+      if ([transformer respondsToSelector:@selector(transformGDTEvent:)]) {
         GDTCORLogDebug(@"Applying a transformer to event %@", event);
-        transformedEvent = [transformer transform:transformedEvent];
+        transformedEvent = [transformer transformGDTEvent:event];
         if (!transformedEvent) {
           completionWrapper(NO, nil);
           return;
         }
       } else {
         GDTCORLogError(GDTCORMCETransformerDoesntImplementTransform,
-                       @"Transformer doesn't implement transform: %@", transformer);
+                       @"Transformer doesn't implement transformGDTEvent: %@", transformer);
         completionWrapper(NO, nil);
         return;
       }

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransformer.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransformer.h
@@ -38,7 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)sharedInstance;
 
-/** Writes the result of applying the given transformers' -transform method on the given event.
+/** Writes the result of applying the given transformers' `transformGDTEvent:` method on the given
+ * event.
  *
  * @note If the app is suspended, a background task will be created to complete work in-progress,
  * but this method will not send any further events until the app is resumed.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h
@@ -68,7 +68,8 @@ typedef NS_ENUM(NSInteger, GDTCORMessageCode) {
   /** For warning messages concerning the reading of a event file. */
   GDTCORMCWFileReadError = 6,
 
-  /** For error messages concerning transform: not being implemented by an event transformer. */
+  /** For error messages concerning transformGDTEvent: not being implemented by an event
+     transformer. */
   GDTCORMCETransformerDoesntImplementTransform = 1000,
 
   /** For error messages concerning the creation of a directory failing. */

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREventTransformer.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREventTransformer.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param event The event to transform.
  * @return A transformed event, or nil if the transformation dropped the event.
  */
-- (nullable GDTCOREvent *)transform:(GDTCOREvent *)event;
+- (nullable GDTCOREvent *)transformGDTEvent:(GDTCOREvent *)event;
 
 @end
 

--- a/GoogleDataTransport/GDTCORTests/Integration/GDTCORIntegrationTest.m
+++ b/GoogleDataTransport/GDTCORTests/Integration/GDTCORIntegrationTest.m
@@ -52,8 +52,8 @@
 
 @implementation GDTCORIntegrationTestTransformer
 
-- (nullable GDTCOREvent *)transform:(GDTCOREvent *)event {
-  // drop half the events during transforming.
+- (nullable GDTCOREvent *)transformGDTEvent:(GDTCOREvent *)event {
+  // Drop half the events during transforming.
   if (arc4random_uniform(2) == 0) {
     event = nil;
   }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORTransformerTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORTransformerTest.m
@@ -37,7 +37,7 @@
 
 @implementation GDTCORTransformerTestNilingTransformer
 
-- (GDTCOREvent *)transform:(GDTCOREvent *)eventEvent {
+- (GDTCOREvent *)transformGDTEvent:(GDTCOREvent *)eventEvent {
   return nil;
 }
 
@@ -48,7 +48,7 @@
 
 @implementation GDTCORTransformerTestNewEventTransformer
 
-- (GDTCOREvent *)transform:(GDTCOREvent *)eventEvent {
+- (GDTCOREvent *)transformGDTEvent:(GDTCOREvent *)eventEvent {
   return [[GDTCOREvent alloc] initWithMappingID:@"new" target:kGDTCORTargetTest];
 }
 


### PR DESCRIPTION
Fixes [#7177](https://github.com/firebase/firebase-ios-sdk/issues/7177)