### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,6 @@ let package = Package(
       ],
       path: "GoogleDataTransport",
       exclude: [
-        "CHANGELOG.md",
-        "README.md",
         "generate_project.sh",
         "GDTCCTWatchOSTestApp/",
         "GDTWatchOSTestApp/",


### PR DESCRIPTION
Removes `CHANGELOG.md` from the excludes section of `GoogleDataTransport` target in package manifest.
This is done because the CHANGELOG.md was moved to root in #19.

Also removes the `README.md` from the excludes section of `GoogleDataTransport` target because that is also at root.