### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ These instructions apply to minor and patch version updates. Major versions need
 a customized adaptation.
 
 After the CI is green:
+* Determine the next version for release by checking the
+  [tagged releases](https://github.com/google/GoogleDataTransport/tags).
+  Ensure that the next release version keeps the Swift PM and CocoaPods versions in sync.
+* Verify that the releasing version is the latest entry in the [CHANGELOG.md](CHANGELOG.md),
+  updating it if necessary.
 * Update the version in the podspec to match the latest entry in the [CHANGELOG.md](CHANGELOG.md)
 * Checkout the `main` branch and ensure it is up to date.
   ```console
@@ -61,23 +66,61 @@ After the CI is green:
   </pre>
 
 ## Publishing
-  * Add a version tag for Swift PM
-    * `git tag {version}`
-    * `git push origin {version}`
-  * `pod trunk push GoogleDataTransport.podspec --skip-tests`
-  * <summary>Clean up SpecsStaging</summary>
-    <details>
+The release process is as follows:
+1. [Tag and release for Swift PM](#swift-package-manager)
+2. [Publish to CocoaPods](#cocoapods)
+3. [Create GitHub Release](#create-github-release)
+4. [Perform post release cleanup](#post-release-cleanup)
 
-    ```console
-        git clone git@github.com:firebase/SpecsStaging.git
-        cd SpecsStaging/
-        git rm -rf GoogleDataTransport/
-        git commit -m "Post publish cleanup"
-        git push origin master
-      ```
-    </details>
-  * [Create GitHub Release](https://github.com/google/GoogleDataTransport/releases/new)
-    * [Template content](https://github.com/google/GoogleDataTransport/releases/edit/9.0.1)
+### Swift Package Manager
+  By creating and [pushing a tag](https://github.com/google/GoogleDataTransport/tags)
+  for Swift PM, the newly tagged version will be immediately released for public use.
+  Given this, please verify the intended time of release for Swift PM.
+  * Add a version tag for Swift PM
+  ```console
+  git tag {version}
+  git push origin {version}
+  ```
+  *Note: Ensure that any inflight PRs that depend on the new `GoogleDataTransport` version are updated to point to the
+  newly tagged version rather than a checksum.*
+  
+### CocoaPods
+* Publish the newly versioned pod to CocoaPods
+
+  It's recommended to point to the `GoogleDataTransport.podspec` in `staging` to make sure the correct spec is being published.
+  ```console
+  pod trunk push ~/.cocoapods/repos/staging/GoogleDataTransport.podspec --skip-tests
+  ```
+
+  The pod push was successful if the above command logs: `🚀  GoogleDataTransport ({version}) successfully published`.
+  In addition, a new commit that publishes the new version (co-authored by [CocoaPodsAtGoogle](https://github.com/CocoaPodsAtGoogle))
+  should appear in the [CocoaPods specs repo](https://github.com/CocoaPods/Specs). Last, the latest version should be displayed
+  on [GoogleDataTransport's CocoaPods page](https://cocoapods.org/pods/GoogleDataTransport).
+
+### [Create GitHub Release](https://github.com/google/GoogleDataTransport/releases/new/)
+  Update the [release template](https://github.com/google/GoogleDataTransport/releases/new/)'s **Tag version** and **Release title**
+  fields with the latest version. In addition, reference the [Release Notes](./CHANGELOG.md) in the release's description.
+  
+  See [this release](https://github.com/google/GoogleDataTransport/releases/edit/9.0.1) for an example.
+  
+  *Don't forget to perform the [post release cleanup](#post-release-cleanup)!*
+
+### Post Release Cleanup
+  <details>
+  <summary>Clean up <b>SpecsStaging</b></summary> 
+
+  ```console
+  pwd=$(pwd)
+  mkdir -p /tmp/release-cleanup && cd $_
+  git clone git@github.com:firebase/SpecsStaging.git
+  cd SpecsStaging/
+  git rm -rf GoogleDataTransport/
+  git commit -m "Post publish cleanup"
+  git push origin master
+  rm -rf /tmp/release-cleanup 
+  cd $pwd
+  ```  
+  </details>
 
 ## Set logging level
 
@@ -87,7 +130,7 @@ After the CI is green:
     ```swift
     import GoogleDataTransport
     ```
-- Set logging level global variable to the desired value before calling `FirebaseApp.config()`:
+- Set logging level global variable to the desired value before calling `FirebaseApp.configure()`:
     ```swift
     GDTCORConsoleLoggerLoggingLevel = GDTCORLoggingLevel.debug.rawValue
     ```
@@ -97,7 +140,7 @@ After the CI is green:
     ```objective-c
     #import <GoogleDataTransport/GoogleDataTransport.h>
     ```
-- Set logging level global variable to the desired value before calling `-[FIRApp config]`:
+- Set logging level global variable to the desired value before calling `-[FIRApp configure]`:
     ```objective-c
     GDTCORConsoleLoggerLoggingLevel = GDTCORLoggingLevelDebug;
     ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The release process is as follows:
   ```
   *Note: Ensure that any inflight PRs that depend on the new `GoogleDataTransport` version are updated to point to the
   newly tagged version rather than a checksum.*
-  
+
 ### CocoaPods
 * Publish the newly versioned pod to CocoaPods
 
@@ -100,14 +100,14 @@ The release process is as follows:
 ### [Create GitHub Release](https://github.com/google/GoogleDataTransport/releases/new/)
   Update the [release template](https://github.com/google/GoogleDataTransport/releases/new/)'s **Tag version** and **Release title**
   fields with the latest version. In addition, reference the [Release Notes](./CHANGELOG.md) in the release's description.
-  
+
   See [this release](https://github.com/google/GoogleDataTransport/releases/edit/9.0.1) for an example.
-  
+
   *Don't forget to perform the [post release cleanup](#post-release-cleanup)!*
 
 ### Post Release Cleanup
   <details>
-  <summary>Clean up <b>SpecsStaging</b></summary> 
+  <summary>Clean up <b>SpecsStaging</b></summary>
 
   ```console
   pwd=$(pwd)
@@ -117,9 +117,9 @@ The release process is as follows:
   git rm -rf GoogleDataTransport/
   git commit -m "Post publish cleanup"
   git push origin master
-  rm -rf /tmp/release-cleanup 
+  rm -rf /tmp/release-cleanup
   cd $pwd
-  ```  
+  ```
   </details>
 
 ## Set logging level


### PR DESCRIPTION
Following GoogleUtilities 7.4.3 release, I went through updated GDT and GULs release instructions to be up-to-date and in sync.

Associated GULs PR https://github.com/google/GoogleUtilities/pull/45

Also added copy and paste friendly block of release cleanup commands.