### PR TITLE
Fix Xcode13b4 Catalyst build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fix Xcode13b4 Catalyst build (#36)
+
 # v9.1.0
 - Bump Promises dependency. (#8334)
 

--- a/Package.swift
+++ b/Package.swift
@@ -104,9 +104,9 @@ let package = Package(
 extension Platform {
   static var catalyst: Self {
     #if swift(>=5.5)
-    Self.macCatalyst
+    return Self.macCatalyst
     #else
-    Self.macOS
+    return Self.macOS
     #endif // swift(>=5.5)
   }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -76,8 +76,8 @@ let package = Package(
         .define("PB_ENABLE_MALLOC", to: "1"),
       ],
       linkerSettings: [
-        .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS])),
-        .linkedFramework("CoreTelephony", .when(platforms: [.macOS, .iOS])),
+        .linkedFramework("SystemConfiguration", .when(platforms: [.iOS, .macOS, .tvOS, .catalyst])),
+        .linkedFramework("CoreTelephony", .when(platforms: [.macOS, .iOS, .catalyst])),
       ]
     ),
     .testTarget(
@@ -100,3 +100,13 @@ let package = Package(
   cLanguageStandard: .c99,
   cxxLanguageStandard: CXXLanguageStandard.gnucxx14
 )
+
+extension Platform {
+  static var catalyst: Self {
+    #if swift(>=5.5)
+    Self.macCatalyst
+    #else
+    Self.macOS
+    #endif // swift(>=5.5)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -104,9 +104,9 @@ let package = Package(
 extension Platform {
   static var catalyst: Self {
     #if swift(>=5.5)
-    return Self.macCatalyst
+      return Self.macCatalyst
     #else
-    return Self.macOS
+      return Self.macOS
     #endif // swift(>=5.5)
   }
 }


### PR DESCRIPTION
A new `Platform` type: [`macCatalyst`](https://developer.apple.com/documentation/swift_packages/platform/3788284-maccatalyst) was added in Xcode 13 (so I wonder if the GDT catalyst build has been broken since b1?).

The fix here is basically the same as seen in https://github.com/firebase/firebase-ios-sdk/pull/6426 to fix https://github.com/firebase/firebase-ios-sdk/issues/6408.

I extended the `Platform` type to conditionally return a platform that Xcode 13 or Xcode 12 will recognize.
I don't think including `.macOS` in the platforms array seems to matter (concluding from 🟢 `spm` CI). Open to other ideas though.

We could remove this fix when we drop Xcode 12

#### Next Steps
- [x] LGTM on this PR
- [x] Update CHANGELOG (Updated `Unreleased`)
- [ ] SPM only patch release `9.1.0`→`9.1.1` (Going to wait til next week for this)