### PR TITLE
Update CHANGELOG for SPM 9.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v9.1.1 (Swift PM)
 - Fix Xcode13b4 Catalyst build (#36)
 
 # v9.1.0


### PR DESCRIPTION
After merging this, **I'll tag and release 9.1.1 for SPM-only today**. This version patches in #36 

Unblocks https://github.com/firebase/quickstart-ios/pull/1279