### PR TITLE
Fix `watchos-testapp` workflow's macOS image

### DIFF
--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -34,11 +34,11 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build
 
   watchos-testapp:
-    runs-on: macOS-latest
+    runs-on: macOS-10.15
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
+    - name: Xcode 12.2
+      run: sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Setup Bundler

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: macOS-10.15
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode 12.2
-      run: sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer
+    - name: Xcode 12
+      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
     - name: Setup Bundler


### PR DESCRIPTION
The workflow job was trying to `xcode-select` an Xcode version that no longer exists on the `macOS-latest` image.

Set the workflow job to run on the  `macOS-10.15` image.

Unblocks CI in #46

Related: https://github.com/firebase/firebase-ios-sdk/pull/7101

#no-changelog