### PR TITLE
[Metrics] Stub out base components

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsController.h"
+
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+@implementation GDTCORMetricsController
+
+- (void)storage:(nonnull id<GDTCORStoragePromiseProtocol>)storage
+    didDropEvent:(nonnull GDTCOREvent *)event {
+  // TODO(nickcooke): Implement.
+}
+
+- (void)storage:(nonnull id<GDTCORStoragePromiseProtocol>)storage
+    didRemoveExpiredEvent:(nonnull GDTCOREvent *)event {
+  // TODO(nickcooke): Implement.
+}
+
+- (void)logEventsDroppedForReason:(GDTCOREventDropReason)reason
+                       eventCount:(NSUInteger)eventCount
+                        mappingID:(nonnull NSString *)mappingID {
+  // TODO(nickcooke): Implement.
+}
+
+- (nonnull FBLPromise<GDTCORMetrics *> *)metrics {
+  // TODO(nickcooke): Implement.
+  return [FBLPromise resolvedWith:nil];
+}
+
+- (nonnull FBLPromise<NSNull *> *)resetMetrics:(nonnull GDTCORMetrics *)metrics {
+  // TODO(nickcooke): Implement.
+  return [FBLPromise resolvedWith:nil];
+}
+
+@end

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+// TODO(nickcooke): Document.
+typedef NS_ENUM(NSInteger, GDTCOREventDropReason) {
+  GDTCOREventDropReasonUnknown = 0,
+  GDTCOREventDropReasonMessageTooOld,
+  GDTCOREventDropReasonStorageFull,
+  GDTCOREventDropReasonPayloadTooBig,
+  GDTCOREventDropReasonMaxRetriesReached,
+  GDTCOREventDropReasonInvalidPayload,
+  GDTCOREventDropReasonServerError
+};

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h"
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h"
+
+@class FBLPromise<ResultType>;
+@class GDTCORMetrics;
+
+NS_ASSUME_NONNULL_BEGIN
+
+// TODO(nickcooke): Document.
+@protocol GDTCORMetricsControllerProtocol <GDTCORStorageDelegate>
+// TODO(nickcooke): Document.
+- (void)logEventsDroppedForReason:(GDTCOREventDropReason)reason
+                       eventCount:(NSUInteger)eventCount
+                        mappingID:(NSString *)mappingID;
+
+// TODO(nickcooke): Document.
+- (FBLPromise<GDTCORMetrics *> *)metrics;
+
+// TODO(nickcooke): Document.
+- (FBLPromise<NSNull *> *)resetMetrics:(GDTCORMetrics *)metrics;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
@@ -168,4 +168,14 @@ FOUNDATION_EXPORT
 id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget(
     GDTCORTarget target);
 
+// TODO(ncooke3): Document.
+@protocol GDTCORStorageDelegate <NSObject>
+// TODO(ncooke3): Document.
+- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage
+    didRemoveExpiredEvent:(GDTCOREvent *)event;
+
+// TODO(ncooke3): Document.
+- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage didDropEvent:(GDTCOREvent *)event;
+@end
+
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsController.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsController.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsController.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GDTCORMetricsController : NSObject <GDTCORMetricsControllerProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This is the initial commit for the new `metrics-main` branch. It stubs out the base components for metric tracking implementation.

I have a series of small PR's queued up.