### PR TITLE
[Metrics] Add plumbing for metrics controller registration

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -24,32 +24,56 @@
 #import "FBLPromises.h"
 #endif
 
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h"
+
 @implementation GDTCORMetricsController
 
-- (void)storage:(nonnull id<GDTCORStoragePromiseProtocol>)storage
-    didDropEvent:(nonnull GDTCOREvent *)event {
-  // TODO(nickcooke): Implement.
++ (void)load {
+  [[GDTCORRegistrar sharedInstance] registerMetricsController:[self sharedInstance] target:kGDTCORTargetCSH];
+  [[GDTCORRegistrar sharedInstance] registerMetricsController:[self sharedInstance] target:kGDTCORTargetFLL];
 }
 
-- (void)storage:(nonnull id<GDTCORStoragePromiseProtocol>)storage
-    didRemoveExpiredEvent:(nonnull GDTCOREvent *)event {
-  // TODO(nickcooke): Implement.
++ (instancetype)sharedInstance {
+  static id sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[self alloc] init];
+  });
+  return sharedInstance;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    // TODO(ncooke3): Implement.
+  }
+  return self;
 }
 
 - (void)logEventsDroppedForReason:(GDTCOREventDropReason)reason
                        eventCount:(NSUInteger)eventCount
                         mappingID:(nonnull NSString *)mappingID {
-  // TODO(nickcooke): Implement.
+  // TODO(ncooke3): Implement.
 }
 
 - (nonnull FBLPromise<GDTCORMetrics *> *)metrics {
-  // TODO(nickcooke): Implement.
+  // TODO(ncooke3): Implement.
   return [FBLPromise resolvedWith:nil];
 }
 
 - (nonnull FBLPromise<NSNull *> *)resetMetrics:(nonnull GDTCORMetrics *)metrics {
-  // TODO(nickcooke): Implement.
+  // TODO(ncooke3): Implement.
   return [FBLPromise resolvedWith:nil];
+}
+
+- (void)storage:(nonnull id<GDTCORStoragePromiseProtocol>)storage
+    didDropEvent:(nonnull GDTCOREvent *)event {
+  // TODO(ncooke3): Implement.
+}
+
+- (void)storage:(nonnull id<GDTCORStoragePromiseProtocol>)storage
+    didRemoveExpiredEvent:(nonnull GDTCOREvent *)event {
+  // TODO(ncooke3): Implement.
 }
 
 @end

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -29,8 +29,10 @@
 @implementation GDTCORMetricsController
 
 + (void)load {
-  [[GDTCORRegistrar sharedInstance] registerMetricsController:[self sharedInstance] target:kGDTCORTargetCSH];
-  [[GDTCORRegistrar sharedInstance] registerMetricsController:[self sharedInstance] target:kGDTCORTargetFLL];
+  [[GDTCORRegistrar sharedInstance] registerMetricsController:[self sharedInstance]
+                                                       target:kGDTCORTargetCSH];
+  [[GDTCORRegistrar sharedInstance] registerMetricsController:[self sharedInstance]
+                                                       target:kGDTCORTargetFLL];
 }
 
 + (instancetype)sharedInstance {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -35,11 +35,16 @@ id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget
 }
 
 @implementation GDTCORRegistrar {
+  // TODO(ncooke3): Replace ivar declarations with @synthesize attributes.
+
   /** Backing ivar for targetToUploader property. */
   NSMutableDictionary<NSNumber *, id<GDTCORUploader>> *_targetToUploader;
 
   /** Backing ivar for targetToStorage property. */
   NSMutableDictionary<NSNumber *, id<GDTCORStorageProtocol>> *_targetToStorage;
+
+  // TODO(ncooke3): Document.
+  NSMutableDictionary<NSNumber *, id<GDTCORMetricsControllerProtocol>> *_targetToMetricsController;
 }
 
 + (instancetype)sharedInstance {
@@ -57,6 +62,7 @@ id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget
     _registrarQueue = dispatch_queue_create("com.google.GDTCORRegistrar", DISPATCH_QUEUE_SERIAL);
     _targetToUploader = [[NSMutableDictionary alloc] init];
     _targetToStorage = [[NSMutableDictionary alloc] init];
+    _targetToMetricsController = [[NSMutableDictionary alloc] init];
   }
   return self;
 }
@@ -83,6 +89,11 @@ id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget
   });
 }
 
+- (void)registerMetricsController:(id<GDTCORMetricsControllerProtocol>)metricsController
+                           target:(GDTCORTarget)target {
+  // TODO(ncooke3): Implement.
+}
+
 - (NSMutableDictionary<NSNumber *, id<GDTCORUploader>> *)targetToUploader {
   __block NSMutableDictionary<NSNumber *, id<GDTCORUploader>> *targetToUploader;
   __weak GDTCORRegistrar *weakSelf = self;
@@ -105,6 +116,12 @@ id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget
     }
   });
   return targetToStorage;
+}
+
+- (NSMutableDictionary<NSNumber *, id<GDTCORMetricsControllerProtocol>> *)
+    targetToMetricsController {
+  // TODO(ncooke3): Implement.
+  return [NSMutableDictionary dictionary];
 }
 
 #pragma mark - GDTCORLifecycleProtocol

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-// TODO(nickcooke): Document.
+// TODO(ncooke3): Document.
 typedef NS_ENUM(NSInteger, GDTCOREventDropReason) {
   GDTCOREventDropReasonUnknown = 0,
   GDTCOREventDropReasonMessageTooOld,

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
@@ -24,17 +24,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// TODO(nickcooke): Document.
+// TODO(ncooke3): Document.
 @protocol GDTCORMetricsControllerProtocol <GDTCORStorageDelegate>
-// TODO(nickcooke): Document.
+// TODO(ncooke3): Document.
 - (void)logEventsDroppedForReason:(GDTCOREventDropReason)reason
                        eventCount:(NSUInteger)eventCount
                         mappingID:(NSString *)mappingID;
 
-// TODO(nickcooke): Document.
+// TODO(ncooke3): Document.
 - (FBLPromise<GDTCORMetrics *> *)metrics;
 
-// TODO(nickcooke): Document.
+// TODO(ncooke3): Document.
 - (FBLPromise<NSNull *> *)resetMetrics:(GDTCORMetrics *)metrics;
 
 @end

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h"
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h"
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORUploader.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORTargets.h"
@@ -44,6 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @param target The target this backend object will be responsible for.
  */
 - (void)registerStorage:(id<GDTCORStorageProtocol>)storage target:(GDTCORTarget)target;
+
+// TODO(ncooke3): Document.
+- (void)registerMetricsController:(id<GDTCORMetricsControllerProtocol>)metricsController
+                           target:(GDTCORTarget)target;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORRegistrar_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORRegistrar_Private.h
@@ -30,6 +30,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, readonly)
     NSMutableDictionary<NSNumber *, id<GDTCORStorageProtocol>> *targetToStorage;
 
+// TODO(ncooke3): Document.
+@property(atomic, readonly)
+    NSMutableDictionary<NSNumber *, id<GDTCORMetricsControllerProtocol>> *targetToMetricsController;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The registration code mirrors that of the other core GDT components (storage and uploader).

Successor PR to first PR: https://github.com/google/GoogleDataTransport/pull/48