### PR TITLE
[Metrics] Add plumbing for passing metrics controller to upload operation

### DIFF
--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -98,6 +98,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
     _uploadURL = uploadURL;
     _storage = storage;
     _metadataProvider = metadataProvider;
+    _metricsController = metricsController;
   }
   return self;
 }

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -68,6 +68,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 @property(nonatomic, readonly) NSURL *uploadURL;
 @property(nonatomic, readonly) id<GDTCORStoragePromiseProtocol> storage;
 @property(nonatomic, readonly) id<GDTCCTUploadMetadataProvider> metadataProvider;
+@property(nonatomic, readonly, nullable) id<GDTCORMetricsControllerProtocol> metricsController;
 
 /** The URL session that will attempt upload. */
 @property(nonatomic) NSURLSession *uploaderSession;
@@ -87,7 +88,8 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
                      uploadURL:(NSURL *)uploadURL
                          queue:(dispatch_queue_t)queue
                        storage:(id<GDTCORStoragePromiseProtocol>)storage
-              metadataProvider:(id<GDTCCTUploadMetadataProvider>)metadataProvider {
+              metadataProvider:(id<GDTCCTUploadMetadataProvider>)metadataProvider
+             metricsController:(nullable id<GDTCORMetricsControllerProtocol>)metricsController {
   self = [super init];
   if (self) {
     _uploaderQueue = queue;

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -89,6 +89,9 @@ static NSURL *_testServerURL = nil;
     return;
   }
 
+  id<GDTCORMetricsControllerProtocol> metricsController =
+      GDTCORMetricsControllerInstanceForTarget(target);
+
   GDTCCTUploadOperation *uploadOperation =
       [[GDTCCTUploadOperation alloc] initWithTarget:target
                                          conditions:conditions

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -98,7 +98,8 @@ static NSURL *_testServerURL = nil;
                                           uploadURL:[[self class] serverURLForTarget:target]
                                               queue:self.uploadQueue
                                             storage:storage
-                                   metadataProvider:self];
+                                   metadataProvider:self
+                                  metricsController:metricsController];
 
   GDTCORLogDebug(@"Upload operation created: %@, target: %@", uploadOperation, @(target));
 

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
@@ -19,6 +19,7 @@
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORUploader.h"
 
 @protocol GDTCORStoragePromiseProtocol;
+@protocol GDTCORMetricsControllerProtocol;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
                          queue:(dispatch_queue_t)queue
                        storage:(id<GDTCORStoragePromiseProtocol>)storage
               metadataProvider:(id<GDTCCTUploadMetadataProvider>)metadataProvider
+             metricsController:(nullable id<GDTCORMetricsControllerProtocol>)metricsController
     NS_DESIGNATED_INITIALIZER;
 
 /** YES if a batch upload attempt was performed. NO otherwise. If NO for the finished operation,

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -38,6 +38,7 @@ FOUNDATION_EXPORT
 id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceForTarget(
     GDTCORTarget target) {
   // TODO(ncooke3): Implement.
+  return nil;
 }
 
 @implementation GDTCORRegistrar {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -34,6 +34,12 @@ id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget
   }
 }
 
+FOUNDATION_EXPORT
+id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceForTarget(
+    GDTCORTarget target) {
+  // TODO(ncooke3): Implement.
+}
+
 @implementation GDTCORRegistrar {
   // TODO(ncooke3): Replace ivar declarations with @synthesize attributes.
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -23,7 +23,6 @@ id<GDTCORStorageProtocol> _Nullable GDTCORStorageInstanceForTarget(GDTCORTarget 
   return [GDTCORRegistrar sharedInstance].targetToStorage[@(target)];
 }
 
-FOUNDATION_EXPORT
 id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget(
     GDTCORTarget target) {
   id storage = [GDTCORRegistrar sharedInstance].targetToStorage[@(target)];
@@ -34,7 +33,6 @@ id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget
   }
 }
 
-FOUNDATION_EXPORT
 id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceForTarget(
     GDTCORTarget target) {
   // TODO(ncooke3): Implement.

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORMetricsControllerProtocol.h
@@ -39,4 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+FOUNDATION_EXPORT
+id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceForTarget(
+    GDTCORTarget target);
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The metrics controller will be passed to each upload operation. 

In future PR, the upload operation will use it's retained metrics controller to fetch metrics for adding to upload batch.