### PR TITLE
Convert Errors logged as Debug to logged as Errors

### DIFF
--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -296,7 +296,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
       futureUploadTime =
           [GDTCORClock clockSnapshotInTheFuture:logResponse.next_request_wait_millis];
     } else if (decodingError) {
-      GDTCORLogDebug(@"There was a response decoding error: %@", decodingError);
+      GDTCORLogError(GDTCORMCEServerDecodingError, @"There was a response decoding error: %@", decodingError);
     }
     pb_release(gdt_cct_LogResponse_fields, &logResponse);
   }
@@ -317,7 +317,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
   }
 
   if (!futureUploadTime) {
-    GDTCORLogDebug(@"%@", @"CCT: The backend response failed to parse, so the next request "
+    GDTCORLogWarning(GDTCORMCEServerDecodingError, @"%@", @"CCT: The backend response failed to parse, so the next request "
                           @"won't occur until 15 minutes from now");
     // 15 minutes from now.
     futureUploadTime = [GDTCORClock clockSnapshotInTheFuture:15 * 60 * 1000];

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -296,7 +296,8 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
       futureUploadTime =
           [GDTCORClock clockSnapshotInTheFuture:logResponse.next_request_wait_millis];
     } else if (decodingError) {
-      GDTCORLogError(GDTCORMCEServerDecodingError, @"There was a response decoding error: %@", decodingError);
+      GDTCORLogError(GDTCORMCEServerDecodingError, @"There was a response decoding error: %@",
+                     decodingError);
     }
     pb_release(gdt_cct_LogResponse_fields, &logResponse);
   }
@@ -317,8 +318,9 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
   }
 
   if (!futureUploadTime) {
-    GDTCORLogWarning(GDTCORMCEServerDecodingError, @"%@", @"CCT: The backend response failed to parse, so the next request "
-                          @"won't occur until 15 minutes from now");
+    GDTCORLogWarning(GDTCORMCEServerDecodingError, @"%@",
+                     @"CCT: The backend response failed to parse, so the next request "
+                     @"won't occur until 15 minutes from now");
     // 15 minutes from now.
     futureUploadTime = [GDTCORClock clockSnapshotInTheFuture:15 * 60 * 1000];
   }

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
@@ -39,7 +39,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
           [[NSJSONSerialization JSONObjectWithData:self.customBytes options:0
                                              error:&error] mutableCopy];
       if (error) {
-        GDTCORLogDebug(@"Error when setting an event's event_code: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
         return;
       }
       NSNumber *eventCode = bytesDict[GDTCCTEventCodeInfo];
@@ -50,7 +50,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                               error:&error];
       }
     } @catch (NSException *exception) {
-      GDTCORLogDebug(@"Error when setting the event for needs_network_connection_info: %@",
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting the event for needs_network_connection_info: %@",
                      exception);
     }
   } else {
@@ -62,7 +62,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                      options:0
                                                        error:&error] mutableCopy];
         if (error) {
-          GDTCORLogDebug(@"Error when setting an even'ts event_code: %@", error);
+          GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an even'ts event_code: %@", error);
           return;
         }
       } else {
@@ -71,7 +71,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       [bytesDict setObject:@YES forKey:GDTCCTNeedsNetworkConnectionInfo];
       self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
     } @catch (NSException *exception) {
-      GDTCORLogDebug(@"Error when setting the event for needs_network_connection_info: %@",
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting the event for needs_network_connection_info: %@",
                      exception);
     }
   }
@@ -86,7 +86,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                                   error:&error];
       return bytesDict && !error && [bytesDict[GDTCCTNeedsNetworkConnectionInfo] boolValue];
     } @catch (NSException *exception) {
-      GDTCORLogDebug(@"Error when checking the event for needs_network_connection_info: %@",
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when checking the event for needs_network_connection_info: %@",
                      exception);
     }
   }
@@ -104,7 +104,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                      options:0
                                                        error:&error] mutableCopy];
         if (error) {
-          GDTCORLogDebug(@"Error when setting an even'ts event_code: %@", error);
+          GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an even'ts event_code: %@", error);
           return;
         }
       } else {
@@ -114,11 +114,11 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
       if (error) {
         self.customBytes = nil;
-        GDTCORLogDebug(@"Error when setting an event's network_connection_info: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's network_connection_info: %@", error);
       }
     }
   } @catch (NSException *exception) {
-    GDTCORLogDebug(@"Error when setting an event's network_connection_info: %@", exception);
+    GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's network_connection_info: %@", exception);
   }
 }
 
@@ -137,13 +137,13 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       NSData *networkConnectionInfoData = [[NSData alloc] initWithBase64EncodedString:base64Data
                                                                               options:0];
       if (error) {
-        GDTCORLogDebug(@"Error when getting an event's network_connection_info: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", error);
         return nil;
       } else {
         return networkConnectionInfoData;
       }
     } @catch (NSException *exception) {
-      GDTCORLogDebug(@"Error when getting an event's network_connection_info: %@", exception);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", exception);
     }
   }
   return nil;
@@ -167,13 +167,13 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       NSNumber *eventCode = [formatter numberFromString:eventCodeString];
 
       if (error) {
-        GDTCORLogDebug(@"Error when getting an event's network_connection_info: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", error);
         return nil;
       } else {
         return eventCode;
       }
     } @catch (NSException *exception) {
-      GDTCORLogDebug(@"Error when getting an event's event_code: %@", exception);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's event_code: %@", exception);
     }
   }
   return nil;
@@ -190,7 +190,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                                       options:0
                                                                         error:&error] mutableCopy];
     if (error) {
-      GDTCORLogDebug(@"Error when setting an event's event_code: %@", error);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
       return;
     }
 
@@ -198,7 +198,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
     self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
     if (error) {
       self.customBytes = nil;
-      GDTCORLogDebug(@"Error when setting an event's event_code: %@", error);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
       return;
     }
     return;
@@ -211,7 +211,7 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       bytesDict = [[NSJSONSerialization JSONObjectWithData:self.customBytes options:0
                                                      error:&error] mutableCopy];
       if (error) {
-        GDTCORLogDebug(@"Error when setting an event's event_code: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
         return;
       }
     } else {
@@ -228,12 +228,12 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
     self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
     if (error) {
       self.customBytes = nil;
-      GDTCORLogDebug(@"Error when setting an event's network_connection_info: %@", error);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's network_connection_info: %@", error);
       return;
     }
 
   } @catch (NSException *exception) {
-    GDTCORLogDebug(@"Error when getting an event's network_connection_info: %@", exception);
+    GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", exception);
   }
 }
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
@@ -39,7 +39,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
           [[NSJSONSerialization JSONObjectWithData:self.customBytes options:0
                                              error:&error] mutableCopy];
       if (error) {
-        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@",
+                       error);
         return;
       }
       NSNumber *eventCode = bytesDict[GDTCCTEventCodeInfo];
@@ -50,7 +51,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                               error:&error];
       }
     } @catch (NSException *exception) {
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting the event for needs_network_connection_info: %@",
+      GDTCORLogError(GDTCORMCESetEventInfoError,
+                     @"Error when setting the event for needs_network_connection_info: %@",
                      exception);
     }
   } else {
@@ -62,7 +64,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                      options:0
                                                        error:&error] mutableCopy];
         if (error) {
-          GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an even'ts event_code: %@", error);
+          GDTCORLogError(GDTCORMCESetEventInfoError,
+                         @"Error when setting an even'ts event_code: %@", error);
           return;
         }
       } else {
@@ -71,7 +74,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       [bytesDict setObject:@YES forKey:GDTCCTNeedsNetworkConnectionInfo];
       self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
     } @catch (NSException *exception) {
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting the event for needs_network_connection_info: %@",
+      GDTCORLogError(GDTCORMCESetEventInfoError,
+                     @"Error when setting the event for needs_network_connection_info: %@",
                      exception);
     }
   }
@@ -86,7 +90,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                                   error:&error];
       return bytesDict && !error && [bytesDict[GDTCCTNeedsNetworkConnectionInfo] boolValue];
     } @catch (NSException *exception) {
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when checking the event for needs_network_connection_info: %@",
+      GDTCORLogError(GDTCORMCESetEventInfoError,
+                     @"Error when checking the event for needs_network_connection_info: %@",
                      exception);
     }
   }
@@ -104,7 +109,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                      options:0
                                                        error:&error] mutableCopy];
         if (error) {
-          GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an even'ts event_code: %@", error);
+          GDTCORLogError(GDTCORMCESetEventInfoError,
+                         @"Error when setting an even'ts event_code: %@", error);
           return;
         }
       } else {
@@ -114,11 +120,13 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
       if (error) {
         self.customBytes = nil;
-        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's network_connection_info: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError,
+                       @"Error when setting an event's network_connection_info: %@", error);
       }
     }
   } @catch (NSException *exception) {
-    GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's network_connection_info: %@", exception);
+    GDTCORLogError(GDTCORMCESetEventInfoError,
+                   @"Error when setting an event's network_connection_info: %@", exception);
   }
 }
 
@@ -137,13 +145,15 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       NSData *networkConnectionInfoData = [[NSData alloc] initWithBase64EncodedString:base64Data
                                                                               options:0];
       if (error) {
-        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError,
+                       @"Error when getting an event's network_connection_info: %@", error);
         return nil;
       } else {
         return networkConnectionInfoData;
       }
     } @catch (NSException *exception) {
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", exception);
+      GDTCORLogError(GDTCORMCESetEventInfoError,
+                     @"Error when getting an event's network_connection_info: %@", exception);
     }
   }
   return nil;
@@ -167,13 +177,15 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       NSNumber *eventCode = [formatter numberFromString:eventCodeString];
 
       if (error) {
-        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError,
+                       @"Error when getting an event's network_connection_info: %@", error);
         return nil;
       } else {
         return eventCode;
       }
     } @catch (NSException *exception) {
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's event_code: %@", exception);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's event_code: %@",
+                     exception);
     }
   }
   return nil;
@@ -190,7 +202,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
                                                                       options:0
                                                                         error:&error] mutableCopy];
     if (error) {
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@",
+                     error);
       return;
     }
 
@@ -198,7 +211,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
     self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
     if (error) {
       self.customBytes = nil;
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
+      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@",
+                     error);
       return;
     }
     return;
@@ -211,7 +225,8 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
       bytesDict = [[NSJSONSerialization JSONObjectWithData:self.customBytes options:0
                                                      error:&error] mutableCopy];
       if (error) {
-        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@", error);
+        GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's event_code: %@",
+                       error);
         return;
       }
     } else {
@@ -228,12 +243,14 @@ NSString *const GDTCCTEventCodeInfo = @"event_code_info";
     self.customBytes = [NSJSONSerialization dataWithJSONObject:bytesDict options:0 error:&error];
     if (error) {
       self.customBytes = nil;
-      GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when setting an event's network_connection_info: %@", error);
+      GDTCORLogError(GDTCORMCESetEventInfoError,
+                     @"Error when setting an event's network_connection_info: %@", error);
       return;
     }
 
   } @catch (NSException *exception) {
-    GDTCORLogError(GDTCORMCESetEventInfoError, @"Error when getting an event's network_connection_info: %@", exception);
+    GDTCORLogError(GDTCORMCESetEventInfoError,
+                   @"Error when getting an event's network_connection_info: %@", exception);
   }
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -164,7 +164,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     // Write the encoded event to the file.
     BOOL writeResult = GDTCORWriteDataToFile(encodedEvent, filePath, &error);
     if (writeResult == NO || error) {
-      GDTCORLogError(GDTCORMCEFileStorageError, @"Attempt to write archive failed: path:%@ error:%@", filePath, error);
+      GDTCORLogError(GDTCORMCEFileStorageError,
+                     @"Attempt to write archive failed: path:%@ error:%@", filePath, error);
       completion(NO, error);
       return;
     } else {
@@ -221,7 +222,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
                                                   toPath:destinationPath
                                                    error:&error];
           if (error) {
-            GDTCORLogError(GDTCORMCEBatchingError, @"An event file wasn't moveable into the batch directory: %@", error);
+            GDTCORLogError(GDTCORMCEBatchingError,
+                           @"An event file wasn't moveable into the batch directory: %@", error);
           }
           [events addObject:event];
         }
@@ -327,7 +329,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           [self.sizeTracker fileWasRemovedAtPath:dataPath withSize:data.length];
           [self.sizeTracker fileWasAddedAtPath:dataPath withSize:newValue.length];
         } else {
-          GDTCORLogError(GDTCORMCEFileStorageError, @"Error writing new value in libraryDataForKey: %@", newValueError);
+          GDTCORLogError(GDTCORMCEFileStorageError,
+                         @"Error writing new value in libraryDataForKey: %@", newValueError);
         }
       }
     }
@@ -437,9 +440,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
 
         // The enumerator finds directories too, but we can't split them, so skip directories
         bool isDirectory = false;
-        NSString *fullPath = [NSString pathWithComponents:@[eventDataPath, path]];
+        NSString *fullPath = [NSString pathWithComponents:@[ eventDataPath, path ]];
         if ([fileManager fileExistsAtPath:fullPath isDirectory:&isDirectory] && isDirectory) {
-
           continue;
         }
 
@@ -451,7 +453,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           NSError *error;
           [fileManager removeItemAtPath:pathToDelete error:&error];
           if (error != nil) {
-            GDTCORLogError(GDTCORMCEFileStorageError, @"There was an error deleting an expired item: %@", error);
+            GDTCORLogError(GDTCORMCEFileStorageError,
+                           @"There was an error deleting an expired item: %@", error);
           } else {
             GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
           }
@@ -490,7 +493,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
                                        error:&error];
   if (batches == nil) {
     *outError = error;
-    GDTCORLogError(GDTCORMCEBatchingError, @"Failed to find event file paths for batchID: %@, error: %@", batchID, error);
+    GDTCORLogError(GDTCORMCEBatchingError,
+                   @"Failed to find event file paths for batchID: %@, error: %@", batchID, error);
     return nil;
   }
 
@@ -590,7 +594,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           GDTCORLogDebug(@"Batched events at path: %@ moved back to the storage: %@", batchDirPath,
                          destinationPath);
         } else {
-          GDTCORLogError(GDTCORMCEBatchingError, @"Error encountered whilst moving events back: %@", error);
+          GDTCORLogError(GDTCORMCEBatchingError, @"Error encountered whilst moving events back: %@",
+                         error);
         }
 
         // Even if not all events where moved back to the storage, there is not much can be done at
@@ -696,7 +701,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSError *error;
     NSArray<NSString *> *dirPaths = [fileManager contentsOfDirectoryAtPath:targetPath error:&error];
     if (error) {
-      GDTCORLogError(GDTCORMCEFileReadError, @"There was an error reading the contents of the target path: %@", error);
+      GDTCORLogError(GDTCORMCEFileReadError,
+                     @"There was an error reading the contents of the target path: %@", error);
       completion(paths);
       return;
     }
@@ -717,7 +723,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
       NSString *filename = [path lastPathComponent];
       NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:filename];
       if (!eventComponents) {
-        GDTCORLogError(GDTCORMCEFileReadError, @"There was an error reading the filename components: %@", eventComponents);
+        GDTCORLogError(GDTCORMCEFileReadError,
+                       @"There was an error reading the filename components: %@", eventComponents);
         continue;
       }
       NSString *eventID = eventComponents[kGDTCOREventComponentsEventIDKey];
@@ -772,7 +779,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSString *mappingID = [[components subarrayWithRange:NSMakeRange(3, components.count - 3)]
         componentsJoinedByString:kMetadataSeparator];
     if (eventID == nil || qosTier == nil || mappingID == nil || expirationDate == nil) {
-      GDTCORLogError(GDTCORMCEFileReadError, @"There was an error parsing the event filename components: %@", components);
+      GDTCORLogError(GDTCORMCEFileReadError,
+                     @"There was an error parsing the event filename components: %@", components);
       return nil;
     }
     return @{
@@ -793,7 +801,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSNumber *batchID = @(components[1].integerValue);
     NSDate *expirationDate = [NSDate dateWithTimeIntervalSince1970:components[2].doubleValue];
     if (target == nil || batchID == nil || expirationDate == nil) {
-      GDTCORLogError(GDTCORMCEBatchingError, @"There was an error parsing the batch filename components: %@", components);
+      GDTCORLogError(GDTCORMCEBatchingError,
+                     @"There was an error parsing the batch filename components: %@", components);
       return nil;
     }
     return @{

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -439,7 +439,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
         }
 
         // The enumerator finds directories too, but we can't split them, so skip directories
-        bool isDirectory = false;
+        BOOL isDirectory = false;
         NSString *fullPath = [NSString pathWithComponents:@[ eventDataPath, path ]];
         if ([fileManager fileExistsAtPath:fullPath isDirectory:&isDirectory] && isDirectory) {
           continue;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -164,7 +164,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     // Write the encoded event to the file.
     BOOL writeResult = GDTCORWriteDataToFile(encodedEvent, filePath, &error);
     if (writeResult == NO || error) {
-      GDTCORLogDebug(@"Attempt to write archive failed: path:%@ error:%@", filePath, error);
+      GDTCORLogError(GDTCORMCEFileStorageError, @"Attempt to write archive failed: path:%@ error:%@", filePath, error);
       completion(NO, error);
       return;
     } else {
@@ -202,7 +202,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
         GDTCOREvent *event =
             (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], eventPath, nil, &error);
         if (event == nil || error) {
-          GDTCORLogDebug(@"Error deserializing event: %@", error);
+          GDTCORLogError(GDTCORMCEBatchingError, @"Error deserializing event: %@", error);
           [[NSFileManager defaultManager] removeItemAtPath:eventPath error:nil];
           continue;
         } else {
@@ -221,7 +221,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
                                                   toPath:destinationPath
                                                    error:&error];
           if (error) {
-            GDTCORLogDebug(@"An event file wasn't moveable into the batch directory: %@", error);
+            GDTCORLogError(GDTCORMCEBatchingError, @"An event file wasn't moveable into the batch directory: %@", error);
           }
           [events addObject:event];
         }
@@ -327,7 +327,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           [self.sizeTracker fileWasRemovedAtPath:dataPath withSize:data.length];
           [self.sizeTracker fileWasAddedAtPath:dataPath withSize:newValue.length];
         } else {
-          GDTCORLogDebug(@"Error writing new value in libraryDataForKey: %@", newValueError);
+          GDTCORLogError(GDTCORMCEFileStorageError, @"Error writing new value in libraryDataForKey: %@", newValueError);
         }
       }
     }
@@ -435,6 +435,14 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           break;
         }
 
+        // The enumerator finds directories too, but we can't split them, so skip directories
+        bool isDirectory = false;
+        NSString *fullPath = [NSString pathWithComponents:@[eventDataPath, path]];
+        if ([fileManager fileExistsAtPath:fullPath isDirectory:&isDirectory] && isDirectory) {
+
+          continue;
+        }
+
         NSString *fileName = [path lastPathComponent];
         NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:fileName];
         NSDate *expirationDate = eventComponents[kGDTCOREventComponentsExpirationKey];
@@ -443,7 +451,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           NSError *error;
           [fileManager removeItemAtPath:pathToDelete error:&error];
           if (error != nil) {
-            GDTCORLogDebug(@"There was an error deleting an expired item: %@", error);
+            GDTCORLogError(GDTCORMCEFileStorageError, @"There was an error deleting an expired item: %@", error);
           } else {
             GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
           }
@@ -482,7 +490,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
                                        error:&error];
   if (batches == nil) {
     *outError = error;
-    GDTCORLogDebug(@"Failed to find event file paths for batchID: %@, error: %@", batchID, error);
+    GDTCORLogError(GDTCORMCEBatchingError, @"Failed to find event file paths for batchID: %@, error: %@", batchID, error);
     return nil;
   }
 
@@ -555,7 +563,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     if ([fileManager removeItemAtPath:batchDirPath error:&error]) {
       GDTCORLogDebug(@"Batch removed at path: %@", batchDirPath);
     } else {
-      GDTCORLogDebug(@"Failed to remove batch at path: %@", batchDirPath);
+      GDTCORLogError(GDTCORMCEBatchingError, @"Failed to remove batch at path: %@", batchDirPath);
     }
   };
 
@@ -582,7 +590,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
           GDTCORLogDebug(@"Batched events at path: %@ moved back to the storage: %@", batchDirPath,
                          destinationPath);
         } else {
-          GDTCORLogDebug(@"Error encountered whilst moving events back: %@", error);
+          GDTCORLogError(GDTCORMCEBatchingError, @"Error encountered whilst moving events back: %@", error);
         }
 
         // Even if not all events where moved back to the storage, there is not much can be done at
@@ -688,7 +696,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSError *error;
     NSArray<NSString *> *dirPaths = [fileManager contentsOfDirectoryAtPath:targetPath error:&error];
     if (error) {
-      GDTCORLogDebug(@"There was an error reading the contents of the target path: %@", error);
+      GDTCORLogError(GDTCORMCEFileReadError, @"There was an error reading the contents of the target path: %@", error);
       completion(paths);
       return;
     }
@@ -709,7 +717,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
       NSString *filename = [path lastPathComponent];
       NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:filename];
       if (!eventComponents) {
-        GDTCORLogDebug(@"There was an error reading the filename components: %@", eventComponents);
+        GDTCORLogError(GDTCORMCEFileReadError, @"There was an error reading the filename components: %@", eventComponents);
         continue;
       }
       NSString *eventID = eventComponents[kGDTCOREventComponentsEventIDKey];
@@ -764,7 +772,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSString *mappingID = [[components subarrayWithRange:NSMakeRange(3, components.count - 3)]
         componentsJoinedByString:kMetadataSeparator];
     if (eventID == nil || qosTier == nil || mappingID == nil || expirationDate == nil) {
-      GDTCORLogDebug(@"There was an error parsing the event filename components: %@", components);
+      GDTCORLogError(GDTCORMCEFileReadError, @"There was an error parsing the event filename components: %@", components);
       return nil;
     }
     return @{
@@ -774,7 +782,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
       kGDTCOREventComponentsMappingIDKey : mappingID
     };
   }
-  GDTCORLogDebug(@"The event filename could not be split: %@", fileName);
+  GDTCORLogError(GDTCORMCEFileReadError, @"The event filename could not be split: %@", fileName);
   return nil;
 }
 
@@ -785,7 +793,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSNumber *batchID = @(components[1].integerValue);
     NSDate *expirationDate = [NSDate dateWithTimeIntervalSince1970:components[2].doubleValue];
     if (target == nil || batchID == nil || expirationDate == nil) {
-      GDTCORLogDebug(@"There was an error parsing the batch filename components: %@", components);
+      GDTCORLogError(GDTCORMCEBatchingError, @"There was an error parsing the batch filename components: %@", components);
       return nil;
     }
     return @{

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -188,7 +188,7 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
                          attributes:nil
                               error:error];
     if (result == NO || *error) {
-      GDTCORLogDebug(@"Attempt to create directory failed: path:%@ error:%@", filePath, *error);
+      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to create directory failed: path:%@ error:%@", filePath, *error);
       return nil;
     }
   }
@@ -198,13 +198,13 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
                                        requiringSecureCoding:YES
                                                        error:error];
     if (resultData == nil || (error != NULL && *error != nil)) {
-      GDTCORLogDebug(@"Encoding an object failed: %@", *error);
+      GDTCORLogError(GDTCORMCEPlatformError, @"Encoding an object failed: %@", *error);
       return nil;
     }
     if (filePath.length > 0) {
       result = [resultData writeToFile:filePath options:NSDataWritingAtomic error:error];
       if (result == NO || *error) {
-        GDTCORLogDebug(@"Attempt to write archive failed: path:%@ error:%@", filePath, *error);
+        GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: path:%@ error:%@", filePath, *error);
       } else {
         GDTCORLogDebug(@"Writing archive succeeded: %@", filePath);
       }
@@ -218,7 +218,7 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
       if (filePath.length > 0) {
         result = [resultData writeToFile:filePath options:NSDataWritingAtomic error:error];
         if (result == NO || *error) {
-          GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", filePath, *error);
+          GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: URL:%@ error:%@", filePath, *error);
         } else {
           GDTCORLogDebug(@"Writing archive succeeded: %@", filePath);
         }
@@ -231,8 +231,12 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
                                userInfo:@{NSLocalizedFailureReasonErrorKey : errorString}];
     }
     if (filePath.length > 0) {
-      GDTCORLogDebug(@"Attempt to write archive. successful:%@ URL:%@ error:%@",
-                     result ? @"YES" : @"NO", filePath, *error);
+      if (result) {
+        GDTCORLogDebug(@"Attempt to write archive. successful:%@ URL:%@ error:%@",
+                       result ? @"YES" : @"NO", filePath, *error);
+      } else {
+        GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed URL:%@ error:%@", filePath, *error);
+      }
     }
   }
   return resultData;
@@ -278,7 +282,7 @@ BOOL GDTCORWriteDataToFile(NSData *data, NSString *filePath, NSError *_Nullable 
                          attributes:nil
                               error:outError];
     if (result == NO || *outError) {
-      GDTCORLogDebug(@"Attempt to create directory failed: path:%@ error:%@", filePath, *outError);
+      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to create directory failed: path:%@ error:%@", filePath, *outError);
       return result;
     }
   }
@@ -286,7 +290,7 @@ BOOL GDTCORWriteDataToFile(NSData *data, NSString *filePath, NSError *_Nullable 
   if (filePath.length > 0) {
     result = [data writeToFile:filePath options:NSDataWritingAtomic error:outError];
     if (result == NO || *outError) {
-      GDTCORLogDebug(@"Attempt to write archive failed: path:%@ error:%@", filePath, *outError);
+      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: path:%@ error:%@", filePath, *outError);
     } else {
       GDTCORLogDebug(@"Writing archive succeeded: %@", filePath);
     }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -188,7 +188,8 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
                          attributes:nil
                               error:error];
     if (result == NO || *error) {
-      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to create directory failed: path:%@ error:%@", filePath, *error);
+      GDTCORLogError(GDTCORMCEPlatformError,
+                     @"Attempt to create directory failed: path:%@ error:%@", filePath, *error);
       return nil;
     }
   }
@@ -204,7 +205,8 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
     if (filePath.length > 0) {
       result = [resultData writeToFile:filePath options:NSDataWritingAtomic error:error];
       if (result == NO || *error) {
-        GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: path:%@ error:%@", filePath, *error);
+        GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: path:%@ error:%@",
+                       filePath, *error);
       } else {
         GDTCORLogDebug(@"Writing archive succeeded: %@", filePath);
       }
@@ -218,7 +220,8 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
       if (filePath.length > 0) {
         result = [resultData writeToFile:filePath options:NSDataWritingAtomic error:error];
         if (result == NO || *error) {
-          GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: URL:%@ error:%@", filePath, *error);
+          GDTCORLogError(GDTCORMCEPlatformError,
+                         @"Attempt to write archive failed: URL:%@ error:%@", filePath, *error);
         } else {
           GDTCORLogDebug(@"Writing archive succeeded: %@", filePath);
         }
@@ -235,7 +238,8 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
         GDTCORLogDebug(@"Attempt to write archive. successful:%@ URL:%@ error:%@",
                        result ? @"YES" : @"NO", filePath, *error);
       } else {
-        GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed URL:%@ error:%@", filePath, *error);
+        GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed URL:%@ error:%@",
+                       filePath, *error);
       }
     }
   }
@@ -282,7 +286,8 @@ BOOL GDTCORWriteDataToFile(NSData *data, NSString *filePath, NSError *_Nullable 
                          attributes:nil
                               error:outError];
     if (result == NO || *outError) {
-      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to create directory failed: path:%@ error:%@", filePath, *outError);
+      GDTCORLogError(GDTCORMCEPlatformError,
+                     @"Attempt to create directory failed: path:%@ error:%@", filePath, *outError);
       return result;
     }
   }
@@ -290,7 +295,8 @@ BOOL GDTCORWriteDataToFile(NSData *data, NSString *filePath, NSError *_Nullable 
   if (filePath.length > 0) {
     result = [data writeToFile:filePath options:NSDataWritingAtomic error:outError];
     if (result == NO || *outError) {
-      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: path:%@ error:%@", filePath, *outError);
+      GDTCORLogError(GDTCORMCEPlatformError, @"Attempt to write archive failed: path:%@ error:%@",
+                     filePath, *outError);
     } else {
       GDTCORLogDebug(@"Writing archive succeeded: %@", filePath);
     }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
@@ -97,7 +97,7 @@ static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability
     dispatch_async(_reachabilityQueue, ^{
       Boolean valid = SCNetworkReachabilityGetFlags(self->_reachabilityRef, &self->_flags);
       if (!valid) {
-        GDTCORLogDebug(@"%@", @"Determining reachability failed.");
+        GDTCORLogWarning(GDTCORMCWReachabilityFailed, @"%@", @"Determining reachability failed.");
         self->_flags = 0;
       }
     });

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h
@@ -100,6 +100,21 @@ typedef NS_ENUM(NSInteger, GDTCORMessageCode) {
 
   /** For errors related to running sqlite. */
   GDTCORMCEDatabaseError = 1009,
+
+  /** For errors related to decoding the server response. */
+  GDTCORMCEServerDecodingError = 1010,
+
+  /** For errors related to setting the event's Network and Event info. */
+  GDTCORMCESetEventInfoError = 1011,
+
+  /** For errors related to writing to file storage */
+  GDTCORMCEFileStorageError = 1012,
+
+  /** For errors related to batching events */
+  GDTCORMCEBatchingError = 1013,
+
+  /** For errors related to platform */
+  GDTCORMCEPlatformError = 1014,
 };
 
 /** Prints the given code and format string to the console.


### PR DESCRIPTION
 - Many error cases were being logged as debug, which hides them in most cases.
 - This also fixes an extra error log where we attempt to split up folders that contain events, eg. if we had an event at `1001/event-name` we would try to split `1001` and print an error.