### PR TITLE
Update to allow update to nanopb 0.3.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v9.1.3
-- Update to allow updates to support nanopb 0.3.9.8 or 0.3.9.9
+- Update to support both nanopb 0.3.9.8 and 0.3.9.9. (#59)
 
 # v9.1.2
 - Fix crash in `GDTCCTUploadOperation` on older iOS versions. (#41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v9.1.3
 - Update to support both nanopb 0.3.9.8 and 0.3.9.9. (#59)
+- GoogleDataTransport now uses the logging level set in GoogleUtilities. (#54)
 
 # v9.1.2
 - Fix crash in `GDTCCTUploadOperation` on older iOS versions. (#41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+# v9.1.3
+- Update to allow updates to support nanopb 0.3.9.8 or 0.3.9.9
+
 # v9.1.2
 - Fix crash in `GDTCCTUploadOperation` on older iOS versions. (#41)
+
 # v9.1.1 (Swift PM)
 - Fix Xcode13b4 Catalyst build (#36)
 

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '9.1.2'
+  s.version          = '9.1.3'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC
@@ -41,7 +41,7 @@ Shared library for iOS SDK data transport needs.
 
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
   s.dependency 'GoogleUtilities/Logger', '~> 7.7'
-  s.dependency 'nanopb', '~> 2.30908.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
   s.dependency 'PromisesObjC', '>= 1.2', '< 3.0'
 
   header_search_paths = {

--- a/GoogleDataTransport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransport/GDTCCTWatchOSTestApp/Podfile
@@ -12,7 +12,7 @@ target 'GDTCCTWatchOSIndependentTestAppWatchKitExtension' do
   pod 'GoogleDataTransport', :path => '../../'
   pod 'FirebaseCore'
   pod 'FirebaseMessaging'
-  pod 'FirebaseStorage'
+  pod 'FirebaseStorage', '> 9.0'
 
 end
 

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     .package(
       name: "nanopb",
       url: "https://github.com/firebase/nanopb.git",
-      "2.30908.0" ..< "2.30909.0"
+      "2.30908.0" ..< "2.30910.0"
     ),
     .package(
       name: "Promises",


### PR DESCRIPTION
See https://github.com/google/nanopb-podspec/pull/19 and https://github.com/firebase/firebase-ios-sdk/pull/9765