### PR TITLE
Rollback #54 and update for 9.1.4 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v9.1.4
+- Rollback logging level changes from v9.1.3. (#60)
+
 # v9.1.3
 - Update to support both nanopb 0.3.9.8 and 0.3.9.9. (#59)
 - GoogleDataTransport now uses the logging level set in GoogleUtilities. (#54)

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '9.1.3'
+  s.version          = '9.1.4'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC
@@ -40,7 +40,6 @@ Shared library for iOS SDK data transport needs.
   s.libraries = ['z']
 
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
-  s.dependency 'GoogleUtilities/Logger', '~> 7.7'
   s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
   s.dependency 'PromisesObjC', '>= 1.2', '< 3.0'
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORConsoleLogger.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORConsoleLogger.m
@@ -16,46 +16,40 @@
 
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h"
 
-#import <GoogleUtilities/GULLogger.h>
+volatile NSInteger GDTCORConsoleLoggerLoggingLevel = GDTCORLoggingLevelErrors;
 
 /** The console logger prefix. */
 static NSString *kGDTCORConsoleLogger = @"[GoogleDataTransport]";
 
 NSString *GDTCORMessageCodeEnumToString(GDTCORMessageCode code) {
-  return [[NSString alloc] initWithFormat:@"I-GDT%06ld", (long)code];
+  return [[NSString alloc] initWithFormat:@"I-GDTCOR%06ld", (long)code];
 }
 
 void GDTCORLog(GDTCORMessageCode code, GDTCORLoggingLevel logLevel, NSString *format, ...) {
+// Don't log anything in not debug builds.
 #if !NDEBUG
-  GULLoggerLevel gulLevel = GULLoggerLevelDebug;
-  switch (logLevel) {
-    case GDTCORLoggingLevelDebug:
-      gulLevel = GULLoggerLevelDebug;
-      break;
-    case GDTCORLoggingLevelVerbose:
-      gulLevel = GULLoggerLevelInfo;
-      break;
-    case GDTCORLoggingLevelWarnings:
-      gulLevel = GULLoggerLevelWarning;
-      break;
-    case GDTCORLoggingLevelErrors:
-      gulLevel = GULLoggerLevelError;
-      break;
-    default:
-      break;
+  if (logLevel >= GDTCORConsoleLoggerLoggingLevel) {
+    NSString *logFormat = [NSString stringWithFormat:@"%@[%@] %@", kGDTCORConsoleLogger,
+                                                     GDTCORMessageCodeEnumToString(code), format];
+    va_list args;
+    va_start(args, format);
+    NSLogv(logFormat, args);
+    va_end(args);
   }
-
-  va_list args;
-  va_start(args, format);
-  GULLogBasic(gulLevel, kGDTCORConsoleLogger, false, GDTCORMessageCodeEnumToString(code), format,
-              args);
-  va_end(args);
 #endif  // !NDEBUG
 }
 
 void GDTCORLogAssert(
     BOOL wasFatal, NSString *_Nonnull file, NSInteger line, NSString *_Nullable format, ...) {
+// Don't log anything in not debug builds.
+#if !NDEBUG
   GDTCORMessageCode code = wasFatal ? GDTCORMCEFatalAssertion : GDTCORMCEGeneralError;
-
-  GDTCORLog(code, GDTCORLoggingLevelErrors, @"(%@:%ld) : %@", file, (long)line, format);
+  NSString *logFormat =
+      [NSString stringWithFormat:@"%@[%@] (%@:%ld) : %@", kGDTCORConsoleLogger,
+                                 GDTCORMessageCodeEnumToString(code), file, (long)line, format];
+  va_list args;
+  va_start(args, format);
+  NSLogv(logFormat, args);
+  va_end(args);
+#endif  // !NDEBUG
 }

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h
@@ -16,6 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+/** The current logging level. This value and higher will be printed. Declared as volatile to make
+ * getting and setting atomic.
+ */
+FOUNDATION_EXPORT volatile NSInteger GDTCORConsoleLoggerLoggingLevel;
+
 /** A  list of logging levels that GDT supports. */
 typedef NS_ENUM(NSInteger, GDTCORLoggingLevel) {
 

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,6 @@ let package = Package(
         .product(name: "nanopb", package: "nanopb"),
         .product(name: "FBLPromises", package: "Promises"),
         .product(name: "GULEnvironment", package: "GoogleUtilities"),
-        .product(name: "GULLogger", package: "GoogleUtilities"),
       ],
       path: "GoogleDataTransport",
       exclude: [

--- a/README.md
+++ b/README.md
@@ -124,13 +124,26 @@ The release process is as follows:
 
 ## Set logging level
 
-GoogleDataTransport will follow the logging level of the underlying
-GoogleUtilities logger. If GoogleDataTransport is being used with a Firebase
-App, you can enable debug logs by adding the command line argument
-`-FIRDebugEnabled` to your app's Arguments Passed on Launch. You can disable
-debug logs with `-FIRDebugDisabled`.
+### Swift
 
-For performance reasons, GoogleDataTransport will not log in release builds.
+- Import `GoogleDataTransport` module:
+    ```swift
+    import GoogleDataTransport
+    ```
+- Set logging level global variable to the desired value before calling `FirebaseApp.configure()`:
+    ```swift
+    GDTCORConsoleLoggerLoggingLevel = GDTCORLoggingLevel.debug.rawValue
+    ```
+### Objective-C
+
+- Import `GoogleDataTransport`:
+    ```objective-c
+    #import <GoogleDataTransport/GoogleDataTransport.h>
+    ```
+- Set logging level global variable to the desired value before calling `-[FIRApp configure]`:
+    ```objective-c
+    GDTCORConsoleLoggerLoggingLevel = GDTCORLoggingLevelDebug;
+    ```
 
 ## Prereqs
 


### PR DESCRIPTION
This reverts commit 1a65c30db4fc841e06586441682c2dda036d9db3 and updates the podspec/CHANGELOG for 9.1.4 patch release.

### Context
- Changes in #54 cause a deadlock at app startup: https://github.com/firebase/firebase-ios-sdk/pull/9768#issuecomment-1119665363
- See how this branch compares to the commit on `main` before #54 merged: https://github.com/google/GoogleDataTransport/compare/5fe18c35562a2a2c463d69165e20f401d98f25b5...nc/rollback-54