### PR TITLE
[Metrics] Add metrics controller unit tests (2)

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -153,7 +153,7 @@
         // newer than metrics represented by the currently stored metrics
         // metadata. In this case, return the existing metadata object as the
         // given metrics are assumed to already be accounted for by the
-        // currenly metadata.
+        // currently stored metadata.
         return metricsMetadata;
       }
     } else {


### PR DESCRIPTION
### Context
-  Followup to #64 
- Add unit tests for the remaining two metrics controller APIs (completes unit testing for metrics controller)
- Fix some small bugs I found while testing