### PR TITLE
[Metrics] Integrate the storage delegate

### DIFF
--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
@@ -33,6 +33,8 @@
   NSMutableDictionary<NSNumber *, NSSet<GDTCOREvent *> *> *_batches;
 }
 
+@synthesize delegate;
+
 - (instancetype)init {
   self = [super init];
   if (self) {

--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
@@ -33,7 +33,7 @@
   NSMutableDictionary<NSNumber *, NSSet<GDTCOREvent *> *> *_batches;
 }
 
-@synthesize delegate;
+@synthesize delegate = _delegate;
 
 - (instancetype)init {
   self = [super init];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -65,6 +65,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
 @implementation GDTCORFlatFileStorage
 
 @synthesize sizeTracker = _sizeTracker;
+@synthesize delegate;
 
 + (void)load {
 #if !NDEBUG
@@ -157,6 +158,10 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
                  userInfo:@{
                    NSLocalizedFailureReasonErrorKey : @"Storage size limit has been reached."
                  }];
+      if (self.delegate != nil) {
+        GDTCORLogDebug(@"%@", @"Delegate notified that 1 event was dropped.");
+        [self.delegate storage:self didDropEvent:event];
+      }
       completion(NO, error);
       return;
     }
@@ -421,6 +426,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     }
 
     // Find expired events and remove them from the storage.
+    NSMutableSet<GDTCOREvent *> *expiredEvents = [NSMutableSet set];
     NSString *eventDataPath = [GDTCORFlatFileStorage eventDataStoragePath];
     NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtPath:eventDataPath];
     NSString *path;
@@ -440,15 +446,36 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
         NSDate *expirationDate = eventComponents[kGDTCOREventComponentsExpirationKey];
         if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now) {
           NSString *pathToDelete = [eventDataPath stringByAppendingPathComponent:path];
-          NSError *error;
-          [fileManager removeItemAtPath:pathToDelete error:&error];
-          if (error != nil) {
-            GDTCORLogDebug(@"There was an error deleting an expired item: %@", error);
+
+          // Decode the expired event from the path to be deleted.
+          NSError *decodeError;
+          GDTCOREvent *event = (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], pathToDelete,
+                                                                  nil, &decodeError);
+          if (event == nil || decodeError) {
+            GDTCORLogDebug(@"Error deserializing event while checking for expired events: %@",
+                           decodeError);
+            event = nil;
+          }
+
+          // Remove the path to be deleted, adding the decoded event to the
+          // event set if the removal was successful.
+          NSError *removeError;
+          [fileManager removeItemAtPath:pathToDelete error:&removeError];
+          if (removeError != nil) {
+            GDTCORLogDebug(@"There was an error deleting an expired item: %@", removeError);
           } else {
             GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
+            if (event) {
+              [expiredEvents addObject:event];
+            }
           }
         }
       }
+    }
+
+    if (self.delegate != nil && [expiredEvents count] > 0) {
+      GDTCORLogDebug(@"Delegate notified that %@ events were dropped.", @(expiredEvents.count));
+      [self.delegate storage:self didRemoveExpiredEvents:[expiredEvents copy]];
     }
 
     [self.sizeTracker resetCachedSize];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -159,7 +159,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
                    NSLocalizedFailureReasonErrorKey : @"Storage size limit has been reached."
                  }];
       if (self.delegate != nil) {
-        GDTCORLogDebug(@"%@", @"Delegate notified that 1 event was dropped.");
+        GDTCORLogDebug(@"Delegate notified that event with mapping ID %@ was dropped.",
+                       event.mappingID);
         [self.delegate storage:self didDropEvent:event];
       }
       completion(NO, error);

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -65,7 +65,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
 @implementation GDTCORFlatFileStorage
 
 @synthesize sizeTracker = _sizeTracker;
-@synthesize delegate;
+@synthesize delegate = _delegate;
 
 + (void)load {
 #if !NDEBUG

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -194,7 +194,9 @@
       return NO;
   }
 
-  // This code path shouldn't be reached.
+  GDTCORLogDebug(@"This code path shouldn't be reached."
+                 @"Invalid target %ld does not support metrics collection",
+                 target);
   return NO;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -194,18 +194,19 @@
       return NO;
   }
 
-  NSAssert(NO, @"This code path shouldn't be reached.");
+  // This code path shouldn't be reached.
+  return NO;
 }
 
 #pragma mark - GDTCORStorageDelegate
 
-- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage
-    didRemoveExpiredEvent:(GDTCOREvent *)event {
-  [self logEventsDroppedForReason:GDTCOREventDropReasonMessageTooOld
-                           events:[NSSet setWithObject:event]];
+- (void)storage:(id<GDTCORStorageProtocol>)storage
+    didRemoveExpiredEvents:(nonnull NSSet<GDTCOREvent *> *)events {
+  [self logEventsDroppedForReason:GDTCOREventDropReasonMessageTooOld events:events];
 }
 
-- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage didDropEvent:(GDTCOREvent *)event {
+- (void)storage:(nonnull id<GDTCORStorageProtocol>)storage
+    didDropEvent:(nonnull GDTCOREvent *)event {
   [self logEventsDroppedForReason:GDTCOREventDropReasonStorageFull
                            events:[NSSet setWithObject:event]];
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -89,11 +89,11 @@ id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceFor
     if (strongSelf) {
       GDTCORLogDebug(@"Registered storage: %@ for target:%ld", storage, (long)target);
       strongSelf->_targetToStorage[@(target)] = storage;
+      [self setMetricsControllerAsStorageDelegateForTarget:target];
     }
   });
 }
 
-// TODO(ncooke3): Add `GDTCORRegistar` test for this API.
 - (void)registerMetricsController:(id<GDTCORMetricsControllerProtocol>)metricsController
                            target:(GDTCORTarget)target {
   __weak GDTCORRegistrar *weakSelf = self;
@@ -103,6 +103,7 @@ id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceFor
       GDTCORLogDebug(@"Registered metrics controller: %@ for target:%ld", metricsController,
                      (long)target);
       strongSelf->_targetToMetricsController[@(target)] = metricsController;
+      [self setMetricsControllerAsStorageDelegateForTarget:target];
     }
   });
 }
@@ -143,6 +144,10 @@ id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceFor
     }
   });
   return targetToMetricsController;
+}
+
+- (void)setMetricsControllerAsStorageDelegateForTarget:(GDTCORTarget)target {
+  _targetToStorage[@(target)].delegate = _targetToMetricsController[@(target)];
 }
 
 #pragma mark - GDTCORLifecycleProtocol

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h
@@ -34,19 +34,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Registers a backend implementation with the GoogleDataTransport infrastructure.
  *
- * @param backend The backend object to register.
+ * @param backend The backend object to register with the given target.
  * @param target The target this backend object will be responsible for.
  */
 - (void)registerUploader:(id<GDTCORUploader>)backend target:(GDTCORTarget)target;
 
 /** Registers a storage implementation with the GoogleDataTransport infrastructure.
  *
- * @param storage The storage instance to be associated with this uploader and target.
- * @param target The target this backend object will be responsible for.
+ * @param storage The storage object to register with the given target.
+ * @param target The target this storage object will be responsible for.
  */
 - (void)registerStorage:(id<GDTCORStorageProtocol>)storage target:(GDTCORTarget)target;
 
-// TODO(ncooke3): Document.
+/** Registers a metrics controller implementation with the GoogleDataTransport infrastructure.
+ *
+ * @param metricsController The metrics controller object to register with the given target.
+ * @param target The target this metrics controller object will be responsible for.
+ */
 - (void)registerMetricsController:(id<GDTCORMetricsControllerProtocol>)metricsController
                            target:(GDTCORTarget)target;
 

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
@@ -27,13 +27,20 @@
 
 @class FBLPromise<ValueType>;
 
+@protocol GDTCORStorageDelegate;
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^GDTCORStorageBatchBlock)(NSNumber *_Nullable newBatchID,
                                         NSSet<GDTCOREvent *> *_Nullable batchEvents);
 
+#pragma mark - GDTCORStorageProtocol
+
 /** Defines the interface a storage subsystem is expected to implement. */
 @protocol GDTCORStorageProtocol <NSObject, GDTCORLifecycleProtocol>
+
+/// The object that acts as the delegate of the storage instance.
+@property(nonatomic, weak, nullable) id<GDTCORStorageDelegate> delegate;
 
 @required
 
@@ -121,6 +128,8 @@ typedef void (^GDTCORStorageBatchBlock)(NSNumber *_Nullable newBatchID,
 
 @end
 
+#pragma mark - GDTCORStoragePromiseProtocol
+
 // TODO(ncooke3): Consider complete replacing block based API by promise API.
 
 @class GDTCORMetricsMetadata;
@@ -173,14 +182,23 @@ FOUNDATION_EXPORT
 id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget(
     GDTCORTarget target);
 
-// TODO(ncooke3): Document.
-@protocol GDTCORStorageDelegate <NSObject>
-// TODO(ncooke3): Document.
-- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage
-    didRemoveExpiredEvent:(GDTCOREvent *)event;
+#pragma mark - GDTCORStorageDelegate
 
-// TODO(ncooke3): Document.
-- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage didDropEvent:(GDTCOREvent *)event;
+/// A type that can be delegated actions from a storage instance.
+@protocol GDTCORStorageDelegate <NSObject>
+
+/// Tells the delegate that the storage instance has removed a set of expired events.
+/// @param storage The storage instance informing the delegate of this impending event.
+/// @param events A set of events that were removed from storage due to their expiration.
+- (void)storage:(id<GDTCORStorageProtocol>)storage
+    didRemoveExpiredEvents:(NSSet<GDTCOREvent *> *)events;
+
+/// Tells the delegate that the storage instance has dropped an event due to the event cache being
+/// full.
+/// @param storage The storage instance informing the delegate of this impending event.
+/// @param event An event that was dropped due to the event cache being full.
+- (void)storage:(id<GDTCORStorageProtocol>)storage didDropEvent:(GDTCOREvent *)event;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, copy, nullable) BOOL (^onTargetSupportsMetricsCollectionHandler)(GDTCORTarget);
 
+@property(nonatomic, copy, nullable) void (^onStorageDidDropEvent)(GDTCOREvent *event);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h
@@ -38,6 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, copy, nullable) void (^onStorageDidDropEvent)(GDTCOREvent *event);
 
+@property(nonatomic, copy, nullable) void (^onStorageDidRemoveExpiredEvents)
+    (NSSet<GDTCOREvent *> *events);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h
@@ -1,18 +1,16 @@
-/*
- * Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import <Foundation/Foundation.h>
 

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
@@ -60,7 +60,11 @@
 }
 
 - (void)storage:(id<GDTCORStoragePromiseProtocol>)storage didDropEvent:(GDTCOREvent *)event {
-  // TODO(ncooke3): Implement.
+  if (self.onStorageDidDropEvent) {
+    return self.onStorageDidDropEvent(event);
+  } else {
+    [self doesNotRecognizeSelector:_cmd];
+  }
 }
 
 - (void)storage:(nonnull id<GDTCORStorageProtocol>)storage

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
@@ -61,12 +61,12 @@
   }
 }
 
-- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage
-    didRemoveExpiredEvent:(GDTCOREvent *)event {
+- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage didDropEvent:(GDTCOREvent *)event {
   // TODO(ncooke3): Implement.
 }
 
-- (void)storage:(id<GDTCORStoragePromiseProtocol>)storage didDropEvent:(GDTCOREvent *)event {
+- (void)storage:(nonnull id<GDTCORStorageProtocol>)storage
+    didRemoveExpiredEvents:(nonnull NSSet<GDTCOREvent *> *)events {
   // TODO(ncooke3): Implement.
 }
 

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
@@ -1,18 +1,16 @@
-/*
- * Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #import "GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.h"
 

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORMetricsControllerFake.m
@@ -69,7 +69,11 @@
 
 - (void)storage:(nonnull id<GDTCORStorageProtocol>)storage
     didRemoveExpiredEvents:(nonnull NSSet<GDTCOREvent *> *)events {
-  // TODO(ncooke3): Implement.
+  if (self.onStorageDidRemoveExpiredEvents) {
+    return self.onStorageDidRemoveExpiredEvents(events);
+  } else {
+    [self doesNotRecognizeSelector:_cmd];
+  }
 }
 
 @end

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -33,7 +33,7 @@
   GDTCORMetricsMetadata *_Nullable _storedMetricsMetadata;
 }
 
-@synthesize delegate;
+@synthesize delegate = _delegate;
 
 + (instancetype)storageFake {
   return [[self alloc] init];

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -33,6 +33,8 @@
   GDTCORMetricsMetadata *_Nullable _storedMetricsMetadata;
 }
 
+@synthesize delegate;
+
 + (instancetype)storageFake {
   return [[self alloc] init];
 }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -797,7 +797,6 @@
       [self expectationWithDescription:@"metricsControllerExpectation"];
   metricsControllerExpectation.inverted = YES;
   metricsController.onStorageDidRemoveExpiredEvents = ^(NSSet<GDTCOREvent *> *events) {
-    XCTAssertTrue(events.count > 0);
     [metricsControllerExpectation fulfill];
   };
 


### PR DESCRIPTION
### Context
- The metrics controller is supposed to act as a delegate to the storage object. 
- The idea is for the storage object to tell the metrics controller when events are dropped so the metrics controller can then record them as dropped.
- This PR integrates the storage delegate and registers the metrics controller as the storage delegate.
- Also, fixed some related documentation and added unit tests.