### PR TITLE
[Metrics] Implement `NSSecureCoding` and add unit tests for `GDTCORMetricsMetadata`

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsMetadata.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsMetadata.m
@@ -16,6 +16,11 @@
 
 #import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsMetadata.h"
 
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCOREventMetricsCounter.h"
+
+static NSString *const kCollectionStartDate = @"collectionStartDate";
+static NSString *const kDroppedEventCounter = @"droppedEventCounter";
+
 @implementation GDTCORMetricsMetadata
 
 + (instancetype)metadataWithCollectionStartDate:(NSDate *)collectedSinceDate
@@ -33,19 +38,53 @@
   return self;
 }
 
+#pragma mark - Equality
+
+- (BOOL)isEqualToMetricsMetadata:(GDTCORMetricsMetadata *)otherMetricsMetadata {
+  return [self.collectionStartDate isEqualToDate:otherMetricsMetadata.collectionStartDate] &&
+         [self.droppedEventCounter
+             isEqualToDroppedEventCounter:otherMetricsMetadata.droppedEventCounter];
+}
+
+- (BOOL)isEqual:(nullable id)object {
+  if (object == nil) {
+    return NO;
+  }
+
+  if (self == object) {
+    return YES;
+  }
+
+  if (![object isKindOfClass:[self class]]) {
+    return NO;
+  }
+
+  return [self isEqualToMetricsMetadata:(GDTCORMetricsMetadata *)object];
+}
+
+- (NSUInteger)hash {
+  return [self.collectionStartDate hash] ^ [self.droppedEventCounter hash];
+}
+
 #pragma mark - NSSecureCoding
 
 + (BOOL)supportsSecureCoding {
   return YES;
 }
 
-- (void)encodeWithCoder:(nonnull NSCoder *)coder {
-  // TODO(ncooke3): Implement
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
+  self = [super init];
+  if (self) {
+    _collectionStartDate = [coder decodeObjectOfClass:[NSDate class] forKey:kCollectionStartDate];
+    _droppedEventCounter = [coder decodeObjectOfClass:[GDTCOREventMetricsCounter class]
+                                               forKey:kDroppedEventCounter];
+  }
+  return self;
 }
 
-- (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
-  // TODO(ncooke3): Implement
-  return nil;
+- (void)encodeWithCoder:(nonnull NSCoder *)coder {
+  [coder encodeObject:self.collectionStartDate forKey:kCollectionStartDate];
+  [coder encodeObject:self.droppedEventCounter forKey:kDroppedEventCounter];
 }
 
 @end

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsMetadata.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsMetadata.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, readonly) NSDate *collectionStartDate;
 
 /// The dropped event counter associated with the metrics.
-@property(nonatomic, copy, readonly, nullable) GDTCOREventMetricsCounter *droppedEventCounter;
+@property(nonatomic, copy, readonly) GDTCOREventMetricsCounter *droppedEventCounter;
 
 /// Creates a metrics metadata object with the provided information.
 /// @param collectedSinceDate The start of the time window over which the metrics were collected.
@@ -38,6 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// This API is unavailable.
 - (instancetype)init NS_UNAVAILABLE;
+
+/// Returns a Boolean value that indicates whether the receiving metrics metadata is equal to
+/// the given metrics metadata.
+/// @param otherMetricsMetadata The metrics metadata with which to compare the
+/// receiving metrics metadata.
+- (BOOL)isEqualToMetricsMetadata:(GDTCORMetricsMetadata *)otherMetricsMetadata;
 
 @end
 

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORMetricsMetadataTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORMetricsMetadataTest.m
@@ -1,0 +1,110 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GoogleDataTransport/GDTCORTests/Unit/GDTCORTestCase.h"
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsMetadata.h"
+
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCOREventDropReason.h"
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORPlatform.h"
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCOREventMetricsCounter.h"
+#import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h"
+
+@interface GDTCORMetricsMetadataTest : XCTestCase
+
+@end
+
+@implementation GDTCORMetricsMetadataTest
+
+- (void)testEqualityEdgeCases {
+  GDTCORMetricsMetadata *metricsMetadata1 =
+      [GDTCORMetricsMetadata metadataWithCollectionStartDate:[NSDate distantPast]
+                                         eventMetricsCounter:[GDTCOREventMetricsCounter counter]];
+  GDTCORMetricsMetadata *metricsMetadata2 = metricsMetadata1;
+  XCTAssert([metricsMetadata1 isEqual:metricsMetadata2]);
+  XCTAssertFalse([metricsMetadata1 isEqual:@"some string"]);
+  XCTAssertFalse([metricsMetadata1 isEqual:nil]);
+}
+
+- (void)testEqualObjectsHaveSameHash {
+  // Given
+  NSArray *events = @[
+    [[GDTCOREvent alloc] initWithMappingID:@"log_src_1" target:kGDTCORTargetTest],
+    [[GDTCOREvent alloc] initWithMappingID:@"log_src_2" target:kGDTCORTargetTest],
+    [[GDTCOREvent alloc] initWithMappingID:@"log_src_2" target:kGDTCORTargetTest],
+  ];
+
+  GDTCOREventMetricsCounter *eventMetricsCounter =
+      [GDTCOREventMetricsCounter counterWithEvents:events
+                                  droppedForReason:GDTCOREventDropReasonStorageFull];
+
+  GDTCORMetricsMetadata *metricsMetadata1 =
+      [GDTCORMetricsMetadata metadataWithCollectionStartDate:[NSDate distantPast]
+                                         eventMetricsCounter:eventMetricsCounter];
+
+  GDTCORMetricsMetadata *metricsMetadata2 =
+      [GDTCORMetricsMetadata metadataWithCollectionStartDate:[NSDate distantPast]
+                                         eventMetricsCounter:eventMetricsCounter];
+
+  GDTCORMetricsMetadata *metricsMetadata3 =
+      [GDTCORMetricsMetadata metadataWithCollectionStartDate:[NSDate distantFuture]
+                                         eventMetricsCounter:[GDTCOREventMetricsCounter counter]];
+  // Then
+  XCTAssertEqualObjects(metricsMetadata1, metricsMetadata2);
+  XCTAssertEqual(metricsMetadata1.hash, metricsMetadata2.hash);
+  XCTAssertNotEqualObjects(metricsMetadata2, metricsMetadata3);
+  XCTAssertNotEqual(metricsMetadata2.hash, metricsMetadata3.hash);
+}
+
+- (void)testSecureCoding {
+  // Given
+  NSArray *events = @[
+    [[GDTCOREvent alloc] initWithMappingID:@"log_src_1" target:kGDTCORTargetTest],
+    [[GDTCOREvent alloc] initWithMappingID:@"log_src_2" target:kGDTCORTargetTest],
+    [[GDTCOREvent alloc] initWithMappingID:@"log_src_2" target:kGDTCORTargetTest],
+  ];
+
+  GDTCOREventMetricsCounter *eventMetricsCounter =
+      [GDTCOREventMetricsCounter counterWithEvents:events
+                                  droppedForReason:GDTCOREventDropReasonStorageFull];
+
+  GDTCORMetricsMetadata *metricsMetadata =
+      [GDTCORMetricsMetadata metadataWithCollectionStartDate:[NSDate date]
+                                         eventMetricsCounter:eventMetricsCounter];
+
+  // When
+  // - Encode the metrics metadata.
+  NSError *encodeError;
+  NSData *encodedMetricsMetadata = GDTCOREncodeArchive(metricsMetadata, nil, &encodeError);
+  XCTAssertNil(encodeError);
+  XCTAssertNotNil(encodedMetricsMetadata);
+
+  // - Write it to disk.
+  NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"metadata.dat"];
+  NSError *writeError;
+  BOOL writeResult = GDTCORWriteDataToFile(encodedMetricsMetadata, filePath, &writeError);
+  XCTAssertNil(writeError);
+  XCTAssertTrue(writeResult);
+
+  // Then
+  // - Decode the metrics metadata from disk.
+  NSError *decodeError;
+  GDTCORMetricsMetadata *decodedMetricsMetadata = (GDTCORMetricsMetadata *)GDTCORDecodeArchive(
+      GDTCORMetricsMetadata.class, filePath, nil, &decodeError);
+  XCTAssertNil(decodeError);
+  XCTAssertNotNil(decodedMetricsMetadata);
+  XCTAssertEqualObjects(decodedMetricsMetadata, metricsMetadata);
+}
+
+@end


### PR DESCRIPTION
### Context
- Follow-up to #67, implement `NSSecureCoding` for `GDTCORMetricsMetadata` and add unit tests.

### Next up
- Now that the necessary data models have functioning `NSSecureCoding` implementations, the next PR will implement the storage-level API to read and write metrics metadata.