### PR TITLE
[Metrics] Implement metrics storage and add unit tests

### DIFF
--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
@@ -209,9 +209,9 @@
       }];
 }
 
-- (FBLPromise<NSNull *> *)fetchAndUpdateClientMetricsWithHandler:
-    (GDTCORMetricsMetadata *_Nullable (^)(GDTCORMetricsMetadata *_Nullable fetchedMetadata,
-                                          NSError *_Nullable fetchError))handler {
+- (FBLPromise<NSNull *> *)fetchAndUpdateMetricsWithHandler:
+    (GDTCORMetricsMetadata * (^)(GDTCORMetricsMetadata *_Nullable fetchedMetadata,
+                                 NSError *_Nullable fetchError))handler {
   // TODO(ncooke3): Implement.
   return [FBLPromise resolvedWith:nil];
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage+Promises.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage+Promises.m
@@ -22,6 +22,10 @@
 #import "FBLPromises.h"
 #endif
 
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORPlatform.h"
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORMetricsMetadata.h"
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORStorageMetadata.h"
 #import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h"
 
 @implementation GDTCORFlatFileStorage (Promises)
@@ -94,16 +98,53 @@
         }];
 }
 
-- (FBLPromise<NSNull *> *)fetchAndUpdateClientMetricsWithHandler:
-    (GDTCORMetricsMetadata *_Nullable (^)(GDTCORMetricsMetadata *_Nullable fetchedMetadata,
-                                          NSError *_Nullable fetchError))handler {
-  // TODO(ncooke3): Implement.
-  return [FBLPromise resolvedWith:nil];
+- (FBLPromise<NSNull *> *)fetchAndUpdateMetricsWithHandler:
+    (GDTCORMetricsMetadata * (^)(GDTCORMetricsMetadata *_Nullable fetchedMetadata,
+                                 NSError *_Nullable fetchError))handler {
+  return FBLPromise.doOn(self.storageQueue, ^id {
+    // Fetch the stored metrics metadata.
+    NSError *decodeError;
+    NSString *metricsMetadataPath =
+        [[[self class] libraryDataStoragePath] stringByAppendingPathComponent:@"metrics_metadata"];
+    GDTCORMetricsMetadata *decodedMetadata = (GDTCORMetricsMetadata *)GDTCORDecodeArchiveAtPath(
+        GDTCORMetricsMetadata.class, metricsMetadataPath, &decodeError);
+
+    // Update the metadata using the retrieved metadata.
+    GDTCORMetricsMetadata *updatedMetadata = handler(decodedMetadata, decodeError);
+    if (updatedMetadata == nil) {
+      // `nil` metadata is not expected and will be a no-op.
+      return nil;
+    }
+
+    if (![updatedMetadata isEqual:decodedMetadata]) {
+      // The metadata was updated so it needs to be saved.
+      // - Encode the updated metadata.
+      NSError *encodeError;
+      NSData *encodedMetadata = GDTCOREncodeArchive(updatedMetadata, nil, &encodeError);
+      if (encodeError) {
+        return encodeError;
+      }
+
+      // - Write the encoded metadata to disk.
+      NSError *writeError;
+      BOOL writeResult = GDTCORWriteDataToFile(encodedMetadata, metricsMetadataPath, &writeError);
+      if (writeResult == NO || writeError) {
+        return writeError;
+      }
+    }
+
+    return nil;
+  });
 }
 
 - (FBLPromise<GDTCORStorageMetadata *> *)fetchStorageMetadata {
-  // TODO(ncooke3): Implement.
-  return [FBLPromise resolvedWith:nil];
+  return FBLPromise.asyncOn(self.storageQueue, ^(FBLPromiseFulfillBlock _Nonnull fulfill,
+                                                 FBLPromiseRejectBlock _Nonnull reject) {
+    [self storageSizeWithCallback:^(GDTCORStorageSizeBytes storageSize) {
+      fulfill([GDTCORStorageMetadata metadataWithCurrentCacheSize:storageSize
+                                                     maxCacheSize:kGDTCORFlatFileStorageSizeLimit]);
+    }];
+  });
 }
 
 // TODO: Move to a separate class/extension when needed in more places.

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -206,7 +206,7 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
       for (NSString *eventPath in paths) {
         NSError *error;
         GDTCOREvent *event =
-            (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], eventPath, nil, &error);
+            (GDTCOREvent *)GDTCORDecodeArchiveAtPath([GDTCOREvent class], eventPath, &error);
         if (event == nil || error) {
           GDTCORLogDebug(@"Error deserializing event: %@", error);
           [[NSFileManager defaultManager] removeItemAtPath:eventPath error:nil];
@@ -450,8 +450,8 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
 
           // Decode the expired event from the path to be deleted.
           NSError *decodeError;
-          GDTCOREvent *event = (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], pathToDelete,
-                                                                  nil, &decodeError);
+          GDTCOREvent *event = (GDTCOREvent *)GDTCORDecodeArchiveAtPath([GDTCOREvent class],
+                                                                        pathToDelete, &decodeError);
           if (event == nil || decodeError) {
             GDTCORLogDebug(@"Error deserializing event while checking for expired events: %@",
                            decodeError);

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -196,7 +196,7 @@
 
   GDTCORLogDebug(@"This code path shouldn't be reached."
                  @"Invalid target %ld does not support metrics collection",
-                 target);
+                 (long)target);
   return NO;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsController.m
@@ -93,7 +93,7 @@
     }
   };
 
-  return [_storage fetchAndUpdateClientMetricsWithHandler:handler];
+  return [_storage fetchAndUpdateMetricsWithHandler:handler];
 }
 
 - (nonnull FBLPromise<GDTCORMetrics *> *)getAndResetMetrics {
@@ -111,7 +111,7 @@
                                            eventMetricsCounter:[GDTCOREventMetricsCounter counter]];
   };
 
-  return [_storage fetchAndUpdateClientMetricsWithHandler:handler]
+  return [_storage fetchAndUpdateMetricsWithHandler:handler]
       .validate(^BOOL(NSNull *__unused _) {
         // Break and reject the promise chain when storage contains no metrics
         // metadata.
@@ -178,7 +178,7 @@
     }
   };
 
-  return [_storage fetchAndUpdateClientMetricsWithHandler:handler];
+  return [_storage fetchAndUpdateMetricsWithHandler:handler];
 }
 
 - (BOOL)isMetricsCollectionSupportedForTarget:(GDTCORTarget)target {

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORPlatform.h
@@ -143,18 +143,23 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
                                       NSString *_Nullable filePath,
                                       NSError *_Nullable *error);
 
-/** Decodes an object of the given class from the given archive path or data and populates the given
- * error if it fails.
- *
- * @param archiveClass The class of the archive's root object.
- * @param archivePath The path to the archived data. Don't use with the archiveData param.
- * @param archiveData The data to decode. Don't use with the archivePath param.
- * @param error The error to populate if something goes wrong.
- */
+/// Decodes an object of the given class from the given archive path and populates the given error
+/// if it fails.
+/// @param archiveClass The class of the archive's root object.
+/// @param archivePath The path to the archived data.
+/// @param error The error to populate if something goes wrong.
+id<NSSecureCoding> _Nullable GDTCORDecodeArchiveAtPath(Class archiveClass,
+                                                       NSString *_Nonnull archivePath,
+                                                       NSError **_Nonnull error);
+
+/// Decodes an object of the given class from the given data and populates the given error if it
+/// fails.
+/// @param archiveClass The class of the archive's root object.
+/// @param archiveData The data to decode.
+/// @param error The error to populate if something goes wrong.
 id<NSSecureCoding> _Nullable GDTCORDecodeArchive(Class archiveClass,
-                                                 NSString *_Nullable archivePath,
-                                                 NSData *_Nullable archiveData,
-                                                 NSError *_Nullable *error);
+                                                 NSData *_Nonnull archiveData,
+                                                 NSError **_Nonnull error);
 
 /** Writes the provided data to a file at the provided  path. Intermediate directories will be
  * created as needed.

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
@@ -149,9 +149,14 @@ typedef void (^GDTCORStorageBatchBlock)(NSNumber *_Nullable newBatchID,
 - (FBLPromise<NSNull *> *)removeAllBatchesForTarget:(GDTCORTarget)target
                                        deleteEvents:(BOOL)deleteEvents;
 
-- (FBLPromise<NSNull *> *)fetchAndUpdateClientMetricsWithHandler:
-    (GDTCORMetricsMetadata *_Nullable (^)(GDTCORMetricsMetadata *_Nullable fetchedMetadata,
-                                          NSError *_Nullable fetchError))handler;
+/// Fetches metrics metadata from storage, passes them to the given handler, and writes the
+/// resulting metrics metadata from the given handler to storage.
+/// @note This API is thread-safe.
+/// @param handler A handler to process the fetch result and return an updated value to store.
+/// @return A promise that is fulfilled if the update is successful, and rejected otherwise.
+- (FBLPromise<NSNull *> *)fetchAndUpdateMetricsWithHandler:
+    (GDTCORMetricsMetadata * (^)(GDTCORMetricsMetadata *_Nullable fetchedMetadata,
+                                 NSError *_Nullable fetchError))handler;
 
 - (FBLPromise<GDTCORStorageMetadata *> *)fetchStorageMetadata;
 

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -116,9 +116,9 @@
   return [FBLPromise resolvedWith:nil];
 }
 
-- (nonnull FBLPromise<NSNull *> *)fetchAndUpdateClientMetricsWithHandler:
-    (nonnull GDTCORMetricsMetadata *_Nullable (^)(GDTCORMetricsMetadata *_Nullable,
-                                                  NSError *_Nullable))handler {
+- (nonnull FBLPromise<NSNull *> *)fetchAndUpdateMetricsWithHandler:
+    (nonnull GDTCORMetricsMetadata * (^)(GDTCORMetricsMetadata *_Nullable,
+                                         NSError *_Nullable))handler {
   if (_storedMetricsMetadata != nil) {
     _storedMetricsMetadata = handler(_storedMetricsMetadata, nil);
   } else {

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -59,7 +59,7 @@
 
   error = nil;
   GDTCORClock *unarchivedClock =
-      (GDTCORClock *)GDTCORDecodeArchive([GDTCORClock class], nil, clockData, &error);
+      (GDTCORClock *)GDTCORDecodeArchive([GDTCORClock class], clockData, &error);
   XCTAssertNil(error);
   XCTAssertNotNil(unarchivedClock);
   XCTAssertEqual([clock hash], [unarchivedClock hash]);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventMetricsCounterTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventMetricsCounterTest.m
@@ -269,8 +269,9 @@ typedef NSDictionary<NSNumber *, NSNumber *> GDTCORDroppedEventCounter;
   // Then
   // - Decode the counter from disk.
   NSError *decodeError;
-  GDTCOREventMetricsCounter *decodedCounter = (GDTCOREventMetricsCounter *)GDTCORDecodeArchive(
-      GDTCOREventMetricsCounter.class, filePath, nil, &decodeError);
+  GDTCOREventMetricsCounter *decodedCounter =
+      (GDTCOREventMetricsCounter *)GDTCORDecodeArchiveAtPath(GDTCOREventMetricsCounter.class,
+                                                             filePath, &decodeError);
   XCTAssertNil(decodeError);
   XCTAssertNotNil(decodedCounter);
   XCTAssertEqualObjects(decodedCounter, eventMetricsCounter);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
@@ -61,7 +61,7 @@
   event = nil;
   error = nil;
   GDTCOREvent *decodedEvent =
-      (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], nil, archiveData, &error);
+      (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], archiveData, &error);
   XCTAssertNil(error);
   XCTAssertNotNil(decodedEvent);
   XCTAssertEqualObjects(decodedEvent.mappingID, @"testID");

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORMetricsMetadataTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORMetricsMetadataTest.m
@@ -100,8 +100,9 @@
   // Then
   // - Decode the metrics metadata from disk.
   NSError *decodeError;
-  GDTCORMetricsMetadata *decodedMetricsMetadata = (GDTCORMetricsMetadata *)GDTCORDecodeArchive(
-      GDTCORMetricsMetadata.class, filePath, nil, &decodeError);
+  GDTCORMetricsMetadata *decodedMetricsMetadata =
+      (GDTCORMetricsMetadata *)GDTCORDecodeArchiveAtPath(GDTCORMetricsMetadata.class, filePath,
+                                                         &decodeError);
   XCTAssertNil(decodeError);
   XCTAssertNotNil(decodedMetricsMetadata);
   XCTAssertEqualObjects(decodedMetricsMetadata, metricsMetadata);


### PR DESCRIPTION
### Context
- I've been working top down and the storage API to fetch and update the metrics metadata is the last component.
- This PR adds a new API to fetch and update metrics metadata using a handler block.
- Added unit tests to validate it's responsibilities.
- Refactored out a decoding function to a new API to separate concerns, improve type safety, and fix subtle bug.

### Next up
- Implement `- transportBytes` for the `GDTCORMetrics` model object to convert it into a proto.

### Next, next up
- Integration and E2E tests