### PR TITLE
[Metrics] Handle potential data corruption when decoding types

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREventMetricsCounter.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREventMetricsCounter.m
@@ -144,14 +144,18 @@ static NSString *const kDroppedEventCounterByMappingID = @"droppedEventCounterBy
 }
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
-  self = [super init];
-  if (self) {
-    _droppedEventCounterByMappingID =
-        [coder decodeObjectOfClasses:
-                   [NSSet setWithArray:@[ NSDictionary.class, NSString.class, NSNumber.class ]]
-                              forKey:kDroppedEventCounterByMappingID];
+  NSDictionary<NSString *, GDTCORDroppedEventCounter *> *droppedEventCounterByMappingID =
+      [coder decodeObjectOfClasses:
+                 [NSSet setWithArray:@[ NSDictionary.class, NSString.class, NSNumber.class ]]
+                            forKey:kDroppedEventCounterByMappingID];
+
+  if (!droppedEventCounterByMappingID ||
+      ![droppedEventCounterByMappingID isKindOfClass:[NSDictionary class]]) {
+    // If any of the fields are corrupted, the initializer should fail.
+    return nil;
   }
-  return self;
+
+  return [self initWithDroppedEventCounterByMappingID:droppedEventCounterByMappingID];
 }
 
 - (void)encodeWithCoder:(nonnull NSCoder *)coder {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsMetadata.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORMetricsMetadata.m
@@ -73,13 +73,19 @@ static NSString *const kDroppedEventCounter = @"droppedEventCounter";
 }
 
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)coder {
-  self = [super init];
-  if (self) {
-    _collectionStartDate = [coder decodeObjectOfClass:[NSDate class] forKey:kCollectionStartDate];
-    _droppedEventCounter = [coder decodeObjectOfClass:[GDTCOREventMetricsCounter class]
-                                               forKey:kDroppedEventCounter];
+  NSDate *collectionStartDate = [coder decodeObjectOfClass:[NSDate class]
+                                                    forKey:kCollectionStartDate];
+  GDTCOREventMetricsCounter *droppedEventCounter =
+      [coder decodeObjectOfClass:[GDTCOREventMetricsCounter class] forKey:kDroppedEventCounter];
+
+  if (!collectionStartDate || !droppedEventCounter ||
+      ![collectionStartDate isKindOfClass:[NSDate class]] ||
+      ![droppedEventCounter isKindOfClass:[GDTCOREventMetricsCounter class]]) {
+    // If any of the fields are corrupted, the initializer should fail.
+    return nil;
   }
-  return self;
+
+  return [self initWithCollectionStartDate:collectionStartDate counter:droppedEventCounter];
 }
 
 - (void)encodeWithCoder:(nonnull NSCoder *)coder {


### PR DESCRIPTION
### Context
- While I expect it to be _very_ unlikely, I wanted to improve the `NSSecureCoding` conformance to detect and gracefully handle possible data corruption. 
- This helps avoid unexpected `nil`-related exceptions/behavior down the line if corrupted data was decoded into either `GDTCORMetricsMetadata` or `GDTCOREventMetricsCounter`.
- Added respective unit tests to test this behavior.