### PR TITLE
[v9.2.0] Update podspec and CHANGELOG for 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v9.2.0
+- Add metrics component to measure SDK performance. (#77)
+
 # v9.1.4
 - Rollback logging level changes from v9.1.3. (#60)
 

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '9.1.4'
+  s.version          = '9.2.0'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
### Context
- Following the merge of `metrics-main` (#77), this PR preps the podspec and CHANGELOG for the 9.2.0 release