### PR TITLE
[Metrics] Add `Foundation` import to header `GDTCORStorageSizeBytes.h`

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageSizeBytes.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageSizeBytes.h
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 /// The data type to represent storage size.
 typedef uint64_t GDTCORStorageSizeBytes;


### PR DESCRIPTION
### Context
- When building with Xcode, the `uint64_t` type is included in the prelude but that doesn't seem to be the case when building internally in g3. So, adding a `Foundation` import seems like a lightweight fix to keep things consistent.
- The related issue that prompted this PR seems to only affect building in g3. 