### PR TITLE
[Infra] Fix source of flake in test helper

### DIFF
--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -1450,6 +1450,10 @@
           [eventStoredExpectation fulfill];
         }];
 
+    dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+                      // Drain queue to allow event to be stored before proceeding.
+                  });
+
     [self waitForExpectations:@[ eventStoredExpectation ] timeout:1];
 
     [generatedEvents addObject:generatedEvent];


### PR DESCRIPTION
### Context
- The flat file storage tests have a helper API to generate events until the storage cache reaches a certain size. Recently, it has become the source of flakes from the storage queue getting backed up enough to prevent the `storeEvent` expectations from getting fulfilled on time. These flakes were hard to reproduce locally and in GHA but were fairly deterministic when building in g3. 
- The fix is to synchronously drain the queue each time an event is stored in the below helper API. 