### PR TITLE
[Cleanup] Synthesize ivars instead of manual declaration

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -38,18 +38,12 @@ id<GDTCORMetricsControllerProtocol> _Nullable GDTCORMetricsControllerInstanceFor
   return [GDTCORRegistrar sharedInstance].targetToMetricsController[@(target)];
 }
 
-@implementation GDTCORRegistrar {
-  // TODO(ncooke3): Replace ivar declarations with @synthesize attributes.
+@implementation GDTCORRegistrar
 
-  /** Backing ivar for targetToUploader property. */
-  NSMutableDictionary<NSNumber *, id<GDTCORUploader>> *_targetToUploader;
-
-  /** Backing ivar for targetToStorage property. */
-  NSMutableDictionary<NSNumber *, id<GDTCORStorageProtocol>> *_targetToStorage;
-
-  /** Backing ivar for targetToMetricsController property. */
-  NSMutableDictionary<NSNumber *, id<GDTCORMetricsControllerProtocol>> *_targetToMetricsController;
-}
+// Manaully synthesize properties declared in `GDTCORRegistrar_Private.h` category.
+@synthesize targetToUploader = _targetToUploader;
+@synthesize targetToStorage = _targetToStorage;
+@synthesize targetToMetricsController = _targetToMetricsController;
 
 + (instancetype)sharedInstance {
   static GDTCORRegistrar *sharedInstance;


### PR DESCRIPTION
### Context
Addresses a TODO I left while working on the metrics feature. Rather than manually declare ivars, explicitly use:
```objc
@synthesize `property` = `_property`
```

#no-changelog
