### PR TITLE
[Infra] Bump clang-format to v15

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup check
       run: |
         brew update
-        brew install clang-format@14
+        brew install clang-format@15
         brew install mint
         mint bootstrap
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ GitHub Actions will verify that any code changes are done in a style compliant
 way. Install `clang-format` and `mint`:
 
 ```console
-brew install clang-format@14
+brew install clang-format@15
 brew install mint
 ```
 


### PR DESCRIPTION
### Context
- Bump clang-format to v15 because of https://github.com/llvm/llvm-project/issues/49340
- See https://github.com/firebase/firebase-ios-sdk/pull/10451
