### PR TITLE
Changing podspec file's license from Apache to Apache-2.0

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -8,7 +8,7 @@ Shared library for iOS SDK data transport needs.
                        DESC
 
   s.homepage         = 'https://developers.google.com/'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
   s.source           = {
     :git => 'https://github.com/google/GoogleDataTransport.git',


### PR DESCRIPTION
This is to address an issue similar to https://github.com/firebase/firebase-ios-sdk/issues/9781.
The pod has `Apache-2.0` license mentioned in the [LICENSE](https://github.com/google/GoogleDataTransport/blob/main/LICENSE).
But, the podspec file sets :license :type as `Apache`
This correction ensures alignment with the correct license, making it consistent and accurate.