### PR TITLE
Add public convenience API for generating a transport event with product data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Added new APIs to support attaching a product ID data to an event.
+- Added new APIs for attaching product ID data to an event.
 
 # v9.2.5
 - Replace 'TARGET_OS_XR' with 'TARGET_OS_VISION' for compatibility with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Added new `GDTCOREvent` initializer to support attaching a product ID to an event.
+- Added new APIs to support attaching a product ID data to an event.
 
 # v9.2.5
 - Replace 'TARGET_OS_XR' with 'TARGET_OS_VISION' for compatibility with

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
@@ -71,6 +71,10 @@
   return [[GDTCOREvent alloc] initWithMappingID:_mappingID target:_target];
 }
 
+- (GDTCOREvent *)eventForTransportWithProductData:(GDTCORProductData *)productData {
+  return [[GDTCOREvent alloc] initWithMappingID:_mappingID productData:productData target:_target];
+}
+
 #pragma mark - Private helper methods
 
 /** Sends the given event through the transport pipeline.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, GDTCOREventQoS) {
 /** The product data that the event is associated with, if any.  */
 @property(nullable, readonly, nonatomic) GDTCORProductData *productData;
 
-/** Initializes an instance using the given mappingID.
+/** Initializes an instance using the given mapping ID and target.
  *
  * @param mappingID The mapping identifier.
  * @param target The event's target identifier.
@@ -86,7 +86,7 @@ typedef NS_ENUM(NSInteger, GDTCOREventQoS) {
  */
 - (nullable instancetype)initWithMappingID:(NSString *)mappingID target:(GDTCORTarget)target;
 
-/** Initializes an instance using the given mappingID.
+/** Initializes an instance using the given mapping ID, product data, and target.
  *
  * @param mappingID The mapping identifier.
  * @param productData The product data to associate this event with.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORTransport.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORTransport.h
@@ -20,6 +20,7 @@
 #import "GDTCORTargets.h"
 
 @class GDTCOREvent;
+@class GDTCORProductData;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -86,6 +87,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @return An event that is suited for use by this transport.
  */
 - (GDTCOREvent *)eventForTransport;
+
+/**
+ * Creates an event with the given product data for use by this transport.
+ *
+ * @param productData The given product data to associate with the created event.
+ * @return An event that is suited for use by this transport.
+ */
+- (GDTCOREvent *)eventForTransportWithProductData:(nonnull GDTCORProductData *)productData;
 
 @end
 

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORProductDataTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORProductDataTest.m
@@ -36,6 +36,18 @@ static int32_t kTestProductID = 123456;
   XCTAssertEqualObjects([productData copy], productData);
 }
 
+- (void)testIsEqualAndHash {
+  GDTCORProductData *productData1 = [[GDTCORProductData alloc] initWithProductID:0000];
+  GDTCORProductData *productData2 = [[GDTCORProductData alloc] initWithProductID:0000];
+  GDTCORProductData *productData3 = [[GDTCORProductData alloc] initWithProductID:1111];
+
+  XCTAssertEqualObjects(productData1, productData2);
+  XCTAssertNotEqualObjects(productData1, productData3);
+
+  XCTAssertEqual(productData1.hash, productData2.hash);
+  XCTAssertNotEqual(productData1.hash, productData3.hash);
+}
+
 - (void)testSecureCoding {
   // Given
   GDTCORProductData *productData = [[GDTCORProductData alloc] initWithProductID:kTestProductID];


### PR DESCRIPTION
Clients typically use the `-[GDTCORTransport eventForTransport]` API to create events. This PR adds an additional factory API to create events with given `productData`. This will likely be preferred over using the `GDTCOREvent` initializer because clients may not retain the `mappingID` and `target` in the context where they wish to create an event for transport.