### PR TITLE
Enable nanopb privacy manifest update

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -40,7 +40,7 @@ Shared library for iOS SDK data transport needs.
   s.libraries = ['z']
 
   s.dependency 'GoogleUtilities/Environment', '~> 7.7'
-  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30910.0'
+  s.dependency 'nanopb', '>= 2.30908.0', '< 2.30911.0'
   s.dependency 'PromisesObjC', '>= 1.2', '< 3.0'
 
   header_search_paths = {


### PR DESCRIPTION
Enable update to nanopb 2.30910 for privacy manifests

Both this and nanopb are already staged at SpecStaging and being tested in https://github.com/firebase/firebase-ios-sdk/pull/12412