### PR TITLE
[NFC] Fix null pointer profiler warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fix null pointer warning from profiler. (#124)
+
 # v9.4.1 (CocoaPods Only)
 - The v9.4.0 podspec did not include the intended dependency range for nanopb
   ([firebase-ios-sdk/#12477](https://github.com/firebase/firebase-ios-sdk/issues/12477))

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORLogSourceMetrics.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORLogSourceMetrics.m
@@ -52,7 +52,7 @@ typedef NSDictionary<NSNumber *, NSNumber *> GDTCORDroppedEventCounter;
     // If the dropped event counter for this event's mapping ID is `nil`,
     // an empty mutable counter is returned.
     NSMutableDictionary<NSNumber *, NSNumber *> *eventCounter =
-        [NSMutableDictionary dictionaryWithDictionary:eventCounterByLogSource[event.mappingID]];
+        [NSMutableDictionary dictionaryWithDictionary:eventCounterByLogSource[event.mappingID] ?: @{}];
 
     // Increment the log source metrics for the given reason.
     NSInteger currentEventCountForReason = [eventCounter[@(reason)] integerValue];


### PR DESCRIPTION
`[NSMutableDictionary  dictionaryWithDictionary:nil]` returns an empty dictionary, but the behavior is undocumented and the signature of the API does not indicate that the dictionary parameter may be nil. This leads to the profiler warning in #124

Fix #124