### PR TITLE
Disable failing watchos test in CI

### DIFF
--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -43,19 +43,21 @@ jobs:
     - name: Setup project and Test Catalyst
       run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build
 
-  watchos-testapp:
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-    - name: Setup Scripts Directory
-      run: ./setup-scripts.sh
-    - name: Setup Bundler
-      run: scripts/setup_bundler.sh
-    - name: Prereqs
-      run: scripts/install_prereqs.sh GoogleDataTransport watchOS xcodebuild
-    - name: Setup project and build watchOS test app
-      run: scripts/third_party/travis/retry.sh scripts/build.sh GoogleDataTransport watchOS xcodebuild
+# TODO: Investigate how to build correctly after build failure introduced by
+# https://github.com/firebase/firebase-ios-sdk/pull/12966
+  # watchos-testapp:
+  #   runs-on: macos-12
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: ruby/setup-ruby@v1
+  #   - name: Setup Scripts Directory
+  #     run: ./setup-scripts.sh
+  #   - name: Setup Bundler
+  #     run: scripts/setup_bundler.sh
+  #   - name: Prereqs
+  #     run: scripts/install_prereqs.sh GoogleDataTransport watchOS xcodebuild
+  #   - name: Setup project and build watchOS test app
+  #     run: scripts/third_party/travis/retry.sh scripts/build.sh GoogleDataTransport watchOS xcodebuild
 
   datatransport-options-matrix:
     runs-on: macos-latest


### PR DESCRIPTION
CI is consistently failing to build the watchOS test app. 

From https://github.com/google/GoogleDataTransport/actions/runs/9154878993:

❌  error: Watch-Only Application Stubs are not available when building for watchOS Simulator. (in target 'GDTWatchOSTestApp' from project 'GDTWatchOSTestApp')

This was introduced when https://github.com/firebase/firebase-ios-sdk/pull/12966 started specifying the sdk parameter to xcodebuild (which is needed to build pod-lib-lint tests for watchos).

It's not obvious how to correctly update the watchOS app builds here and in messaging.yml, so disabling for now.