### PR TITLE
[v10] Remove GoogleUtilities dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v10.0.0
 - Fix null pointer warning from profiler. (#124)
 - [changed] **Breaking change**: Platform Minimum supported version updates:
-    - | Platform  | GoogleUtilities 8.0|
+    - | Platform  | GoogleDataTransport 10.0|
       | ------------- | ------------- |
       | iOS  | **12.0**  |
       | tvOS  | **13.0**  |

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -39,7 +39,6 @@ Shared library for iOS SDK data transport needs.
 
   s.libraries = ['z']
 
-  s.dependency 'GoogleUtilities/Environment', '~> 8.0'
   s.dependency 'nanopb', '~> 3.30910.0'
   s.dependency 'PromisesObjC', '~> 2.4'
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTURLSessionDataResponse.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTURLSessionDataResponse.m
@@ -1,0 +1,8 @@
+//
+//  GDTCCTURLSessionDataResponse.m
+//  GoogleDataTransport
+//
+//  Created by Nick Cooke on 6/12/24.
+//
+
+#import <Foundation/Foundation.h>

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTURLSessionDataResponse.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTURLSessionDataResponse.m
@@ -1,8 +1,28 @@
+// Copyright 2024 Google LLC
 //
-//  GDTCCTURLSessionDataResponse.m
-//  GoogleDataTransport
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Nick Cooke on 6/12/24.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#import <Foundation/Foundation.h>
+#import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h"
+
+@implementation GDTCCTURLSessionDataResponse
+
+- (instancetype)initWithResponse:(NSHTTPURLResponse *)response HTTPBody:(NSData *)body {
+  self = [super init];
+  if (self) {
+    _HTTPResponse = response;
+    _HTTPBody = body;
+  }
+  return self;
+}
+
+@end

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -34,11 +34,11 @@
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
 
-#import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h"
-#import "GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"
+#import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCOREvent+GDTMetricsSupport.h"
+#import "GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h"
 
 #import "GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h"
 
@@ -287,7 +287,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 
 /** Composes and sends URL request. */
 - (FBLPromise<GDTCCTURLSessionDataResponse *> *)sendURLRequestWithBatch:(GDTCORUploadBatch *)batch
-                                                              target:(GDTCORTarget)target {
+                                                                 target:(GDTCORTarget)target {
   return [FBLPromise
              onQueue:self.uploaderQueue
                   do:^NSURLRequest * {
@@ -309,8 +309,8 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
       .thenOn(self.uploaderQueue,
               ^FBLPromise<GDTCCTURLSessionDataResponse *> *(NSURLRequest *request) {
                 // 2. Send URL request.
-                return
-                    [[self uploaderSessionCreateIfNeeded] gdtcct_dataTaskPromiseWithRequest:request];
+                return [[self uploaderSessionCreateIfNeeded]
+                    gdtcct_dataTaskPromiseWithRequest:request];
               })
       .thenOn(self.uploaderQueue,
               ^GDTCCTURLSessionDataResponse *(GDTCCTURLSessionDataResponse *response) {

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -34,8 +34,8 @@
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
 
-#import <GoogleUtilities/GULURLSessionDataResponse.h>
-#import <GoogleUtilities/NSURLSession+GULPromises.h>
+#import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h"
+#import "GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCOREvent+GDTMetricsSupport.h"
@@ -227,7 +227,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
   // 1. Send URL request.
   return [self sendURLRequestWithBatch:batch target:target]
       .thenOn(self.uploaderQueue,
-              ^FBLPromise *(GULURLSessionDataResponse *response) {
+              ^FBLPromise *(GDTCCTURLSessionDataResponse *response) {
                 // 2. Update the next upload time and process response.
                 [self updateNextUploadTimeWithResponse:response forTarget:target];
 
@@ -246,7 +246,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 }
 
 /** Processes a URL session response for a given batch from storage. */
-- (FBLPromise<NSNull *> *)processResponse:(GULURLSessionDataResponse *)response
+- (FBLPromise<NSNull *> *)processResponse:(GDTCCTURLSessionDataResponse *)response
                                  forBatch:(GDTCORUploadBatch *)batch
                                   storage:(id<GDTCORStoragePromiseProtocol>)storage {
   // Cleanup batch based on the response's status code.
@@ -286,7 +286,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 }
 
 /** Composes and sends URL request. */
-- (FBLPromise<GULURLSessionDataResponse *> *)sendURLRequestWithBatch:(GDTCORUploadBatch *)batch
+- (FBLPromise<GDTCCTURLSessionDataResponse *> *)sendURLRequestWithBatch:(GDTCORUploadBatch *)batch
                                                               target:(GDTCORTarget)target {
   return [FBLPromise
              onQueue:self.uploaderQueue
@@ -307,13 +307,13 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
                     return request;
                   }]
       .thenOn(self.uploaderQueue,
-              ^FBLPromise<GULURLSessionDataResponse *> *(NSURLRequest *request) {
+              ^FBLPromise<GDTCCTURLSessionDataResponse *> *(NSURLRequest *request) {
                 // 2. Send URL request.
                 return
-                    [[self uploaderSessionCreateIfNeeded] gul_dataTaskPromiseWithRequest:request];
+                    [[self uploaderSessionCreateIfNeeded] gdtcct_dataTaskPromiseWithRequest:request];
               })
       .thenOn(self.uploaderQueue,
-              ^GULURLSessionDataResponse *(GULURLSessionDataResponse *response) {
+              ^GDTCCTURLSessionDataResponse *(GDTCCTURLSessionDataResponse *response) {
                 // Invalidate session to release the delegate (which is `self`) to break the retain
                 // cycle.
                 [self.uploaderSession finishTasksAndInvalidate];
@@ -328,7 +328,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 }
 
 /** Parses server response and update next upload time for the specified target based on it. */
-- (void)updateNextUploadTimeWithResponse:(GULURLSessionDataResponse *)response
+- (void)updateNextUploadTimeWithResponse:(GDTCCTURLSessionDataResponse *)response
                                forTarget:(GDTCORTarget)target {
   GDTCORClock *futureUploadTime;
   if (response.HTTPBody) {

--- a/GoogleDataTransport/GDTCCTLibrary/NSURLSession+GDTCCTPromises.m
+++ b/GoogleDataTransport/GDTCCTLibrary/NSURLSession+GDTCCTPromises.m
@@ -1,0 +1,8 @@
+//
+//  NSURLSession+GDTCCTPromises.m
+//  GoogleDataTransport
+//
+//  Created by Nick Cooke on 6/12/24.
+//
+
+#import <Foundation/Foundation.h>

--- a/GoogleDataTransport/GDTCCTLibrary/NSURLSession+GDTCCTPromises.m
+++ b/GoogleDataTransport/GDTCCTLibrary/NSURLSession+GDTCCTPromises.m
@@ -1,8 +1,44 @@
+// Copyright 2024 Google LLC
 //
-//  NSURLSession+GDTCCTPromises.m
-//  GoogleDataTransport
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Nick Cooke on 6/12/24.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#import <Foundation/Foundation.h>
+#import "GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h"
+
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+#import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h"
+
+@implementation NSURLSession (GDTCCTPromises)
+
+- (FBLPromise<GDTCCTURLSessionDataResponse *> *)gdtcct_dataTaskPromiseWithRequest:
+    (NSURLRequest *)URLRequest {
+  return [FBLPromise async:^(FBLPromiseFulfillBlock fulfill, FBLPromiseRejectBlock reject) {
+    [[self dataTaskWithRequest:URLRequest
+             completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
+                                 NSError *_Nullable error) {
+               if (error) {
+                 reject(error);
+               } else {
+                 fulfill([[GDTCCTURLSessionDataResponse alloc]
+                     initWithResponse:(NSHTTPURLResponse *)response
+                             HTTPBody:data]);
+               }
+             }] resume];
+  }];
+}
+
+@end

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h
@@ -1,12 +1,29 @@
+// Copyright 2024 Google LLC
 //
-//  GDTCCTURLSessionDataResponse.h
-//  GoogleDataTransport
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Nick Cooke on 6/12/24.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#ifndef GDTCCTURLSessionDataResponse_h
-#define GDTCCTURLSessionDataResponse_h
+#import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
-#endif /* GDTCCTURLSessionDataResponse_h */
+/** The class represents HTTP response received from `NSURLSession`. */
+@interface GDTCCTURLSessionDataResponse : NSObject
+
+@property(nonatomic, readonly) NSHTTPURLResponse *HTTPResponse;
+@property(nonatomic, nullable, readonly) NSData *HTTPBody;
+
+- (instancetype)initWithResponse:(NSHTTPURLResponse *)response HTTPBody:(nullable NSData *)body;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTURLSessionDataResponse.h
@@ -1,0 +1,12 @@
+//
+//  GDTCCTURLSessionDataResponse.h
+//  GoogleDataTransport
+//
+//  Created by Nick Cooke on 6/12/24.
+//
+
+#ifndef GDTCCTURLSessionDataResponse_h
+#define GDTCCTURLSessionDataResponse_h
+
+
+#endif /* GDTCCTURLSessionDataResponse_h */

--- a/GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h
@@ -1,0 +1,12 @@
+//
+//  NSURLSession+GDTCCTPromises.h
+//  GCDWebServer
+//
+//  Created by Nick Cooke on 6/12/24.
+//
+
+#ifndef NSURLSession_GDTCCTPromises_h
+#define NSURLSession_GDTCCTPromises_h
+
+
+#endif /* NSURLSession_GDTCCTPromises_h */

--- a/GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/NSURLSession+GDTCCTPromises.h
@@ -1,12 +1,35 @@
+// Copyright 2024 Google LLC
 //
-//  NSURLSession+GDTCCTPromises.h
-//  GCDWebServer
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by Nick Cooke on 6/12/24.
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-#ifndef NSURLSession_GDTCCTPromises_h
-#define NSURLSession_GDTCCTPromises_h
+#import <Foundation/Foundation.h>
 
+@class FBLPromise<Value>;
+@class GDTCCTURLSessionDataResponse;
 
-#endif /* NSURLSession_GDTCCTPromises_h */
+NS_ASSUME_NONNULL_BEGIN
+
+/** Promise based API for `NSURLSession`. */
+@interface NSURLSession (GDTCCTPromises)
+
+/** Creates a promise wrapping `-[NSURLSession dataTaskWithRequest:completionHandler:]` method.
+ * @param URLRequest The request to create a data task with.
+ * @return A promise that is fulfilled when an HTTP response is received (with any response code),
+ * or is rejected with the error passed to the task completion.
+ */
+- (FBLPromise<GDTCCTURLSessionDataResponse *> *)gdtcct_dataTaskPromiseWithRequest:
+    (NSURLRequest *)URLRequest;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Package.swift
+++ b/Package.swift
@@ -35,11 +35,6 @@ let package = Package(
       url: "https://github.com/google/promises.git",
       "2.4.0" ..< "3.0.0"
     ),
-    .package(
-      url: "https://github.com/google/GoogleUtilities.git",
-      // TODO: Update to '"8.0.0" ..< "9.0.0"' when ready.
-      branch: "release-8.0"
-    ),
   ],
   // TODO: Restructure directory structure to simplify the excludes here.
   targets: [
@@ -48,7 +43,6 @@ let package = Package(
       dependencies: [
         .product(name: "nanopb", package: "nanopb"),
         .product(name: "FBLPromises", package: "Promises"),
-        .product(name: "GULEnvironment", package: "GoogleUtilities"),
       ],
       path: "GoogleDataTransport",
       exclude: [


### PR DESCRIPTION
GDT depended on GoogleUtilities solely to use GoogleUtilities's promise based APIs deleted in https://github.com/google/GoogleUtilities/pull/186