### PR TITLE
[v10] Merge main into release-10.0, bump nanopb to 2.30910.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/firebase/nanopb.git",
-      "2.30908.0" ..< "2.30911.0"
+      "2.30910.0" ..< "2.30911.0"
     ),
     .package(
       url: "https://github.com/google/promises.git",


### PR DESCRIPTION
Fix merge conflicts in https://github.com/google/GoogleDataTransport/pull/141 and bump `nanopb` minimum to `2.30910.0` in `Package.swift`.