### PR TITLE
add analyze to ci

### DIFF
--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build analyze
+      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build
 
 # TODO: Investigate how to build correctly after build failure introduced by
 # https://github.com/firebase/firebase-ios-sdk/pull/12966
@@ -78,4 +78,4 @@ jobs:
       run: ./scripts/setup_bundler.sh
     - name: PodLibLint DataTransport Cron
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }} --analyze

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build --analyze
+      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build analyze
 
 # TODO: Investigate how to build correctly after build failure introduced by
 # https://github.com/firebase/firebase-ios-sdk/pull/12966

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -29,7 +29,7 @@ jobs:
       run: ./scripts/setup_bundler.sh
     - name: PodLibLint DataTransport
       run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=${{ matrix.target }}
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=${{ matrix.target }} --analyze
 
   catalyst:
     runs-on: macOS-latest
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build
+      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh GoogleDataTransport build --analyze
 
 # TODO: Investigate how to build correctly after build failure introduced by
 # https://github.com/firebase/firebase-ios-sdk/pull/12966


### PR DESCRIPTION
The flagged line in https://github.com/firebase/quickstart-ios/issues/1595 doesn't seem to be a valid issue, but we should still be running static analyzer in CI.