### PR TITLE
[Infra] Prefer `setup_check.sh` over manual config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,11 +32,7 @@ jobs:
       run: ./setup-scripts.sh
 
     - name: Setup check
-      run: |
-        brew update
-        brew install clang-format@19
-        brew install mint
-        mint bootstrap
+      run: scripts/setup_check.sh
 
     - name: Style
       run: scripts/style.sh test-only

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORAssert.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORAssert.m
@@ -24,8 +24,9 @@ GDTCORAssertionBlock GDTCORAssertionBlockToRunInstead(void) {
     if (assertionBlockSEL) {
       IMP assertionBlockIMP = [GDTCORAssertClass methodForSelector:assertionBlockSEL];
       if (assertionBlockIMP) {
-        GDTCORAssertionBlock assertionBlock = ((GDTCORAssertionBlock(*)(id, SEL))assertionBlockIMP)(
-            GDTCORAssertClass, assertionBlockSEL);
+        GDTCORAssertionBlock assertionBlock =
+            ((GDTCORAssertionBlock (*)(id, SEL))assertionBlockIMP)(GDTCORAssertClass,
+                                                                   assertionBlockSEL);
         if (assertionBlock) {
           return assertionBlock;
         }


### PR DESCRIPTION
This simplifies things by getting clang-format from the `firebase-ios-sdk` checkout during CI rather than from this repo.

Corresponding GoogleUtils PR: https://github.com/google/GoogleUtilities/pull/218