### PR TITLE
Use Xcode 16 in CI

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -21,6 +21,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests


### PR DESCRIPTION
The build script now requires at least Xcode 16