### PR TITLE
Fix GDTCORFlatFileStorage crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v10.1.1
+- Fix `GDTCORFlatFileStorage` crash.
+  ([firebase-ios-sdk/#14645](https://github.com/firebase/firebase-ios-sdk/issues/14645))
+
 # v10.1.0
 - Fix `[FBLPromise HTTPBody]` SwiftUI Previews crash when using binary
   distribution. ([firebase-ios-sdk/#13318](https://github.com/firebase/firebase-ios-sdk/issues/13318),

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORPlatformTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORPlatformTest.m
@@ -78,4 +78,26 @@
   XCTAssertNoThrow([application endBackgroundTask:bgID]);
 }
 
+- (void)testGDTCORWriteDataToFile {
+  NSString *directoryPath =
+      [NSTemporaryDirectory() stringByAppendingPathComponent:@"testGDTCORWriteDataToFile"];
+  NSString *filePath = [directoryPath stringByAppendingPathComponent:@"testFile.txt"];
+  NSData *data = [@"testData" dataUsingEncoding:NSUTF8StringEncoding];
+
+  // Clean up any old test artifacts.
+  [[NSFileManager defaultManager] removeItemAtPath:directoryPath error:nil];
+
+  // Write the data to the file.
+  NSError *error;
+  XCTAssertTrue(GDTCORWriteDataToFile(data, filePath, &error));
+  XCTAssertNil(error);
+
+  // Verify that the file was created and contains the correct data.
+  NSData *readData = [NSData dataWithContentsOfFile:filePath];
+  XCTAssertEqualObjects(data, readData);
+
+  // Clean up the test artifacts.
+  [[NSFileManager defaultManager] removeItemAtPath:directoryPath error:nil];
+}
+
 @end


### PR DESCRIPTION
Fix https://github.com/firebase/firebase-ios-sdk/issues/14645

Gemini's analysis:
✦ I understand you're seeing a crash on iOS 18.3.2 related to directory enumeration in GDTCORFlatFileStorage. Based on the crash log you provided, the issue appears to stem from directory
  creation (_mkpath, fstatat) within the storeEvent method, rather than enumeration. This could be due to a file system issue or a problem with how the storage path is being constructed or
  accessed.

✦ After reviewing GDTCORFlatFileStorage.m, I've confirmed that the crash likely occurs within the storeEvent:onComplete: method. Specifically, the call to GDTCORWriteDataToFile seems to be
  the source of the issue, as this is where the directory creation happens.

  The stack trace indicates a failure in the underlying file system calls (_mkpath and fstatat) during directory creation. This could be due to a bug in iOS 18.3.2. A potential workaround
  is to check if the directory exists before attempting to create it. This avoids unnecessarily calling createDirectoryAtPath if the directory is already present, which may prevent the
  crash.

I've analyzed GDTCORPlatform.m and found that GDTCORWriteDataToFile is responsible for creating the directory before writing an event to a file. The current implementation directly
  attempts to create the directory, which, as we've seen, can cause a crash on iOS 18.3.2.

  To address this, I will modify GDTCORWriteDataToFile to first check if the directory already exists. If it does not, the code will then proceed to create it. This preventative check
  should avoid the crash. I'll now apply this change.