### PR TITLE
Fix SPM GoogleDataTransport version define

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
       publicHeadersPath: "GDTCORLibrary/Public",
       cSettings: [
         .headerSearchPath("../"),
-        .define("GDTCOR_VERSION", to: "0.0.1"),
+        .define("GDTCOR_VERSION", to: "10.1.0"),
         .define("PB_FIELD_32BIT", to: "1"),
         .define("PB_NO_PACKED_STRUCTS", to: "1"),
         .define("PB_ENABLE_MALLOC", to: "1"),


### PR DESCRIPTION
## Summary
- update the Swift Package Manager GDTCOR_VERSION define from 0.0.1 to 10.1.0
- align the SPM build with the current GoogleDataTransport podspec version

## Validation
- verified GoogleDataTransport.podspec declares version 10.1.0
- verified Package.swift now defines GDTCOR_VERSION as 10.1.0