### PR TITLE
Fix EXC_BAD_ACCESS in GDTCORLogAssert when path contains % characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Fix `EXC_BAD_ACCESS` crash in `GDTCORLogAssert` when a user's project path contains `%` characters. ([#16455](https://github.com/firebase/firebase-ios-sdk/issues/16455))
 - Cancel upload operation when background task expires.
 - Log error when handling directory enumeration.
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORConsoleLogger.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORConsoleLogger.m
@@ -29,12 +29,13 @@ void GDTCORLog(GDTCORMessageCode code, GDTCORLoggingLevel logLevel, NSString *fo
 // Don't log anything in not debug builds.
 #if !NDEBUG
   if (logLevel >= GDTCORConsoleLoggerLoggingLevel) {
-    NSString *logFormat = [NSString stringWithFormat:@"%@[%@] %@", kGDTCORConsoleLogger,
-                                                     GDTCORMessageCodeEnumToString(code), format];
     va_list args;
     va_start(args, format);
-    NSLogv(logFormat, args);
+    NSString *message =
+        format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
     va_end(args);
+
+    NSLog(@"%@[%@] %@", kGDTCORConsoleLogger, GDTCORMessageCodeEnumToString(code), message);
   }
 #endif  // !NDEBUG
 }
@@ -44,12 +45,14 @@ void GDTCORLogAssert(
 // Don't log anything in not debug builds.
 #if !NDEBUG
   GDTCORMessageCode code = wasFatal ? GDTCORMCEFatalAssertion : GDTCORMCEGeneralError;
-  NSString *logFormat =
-      [NSString stringWithFormat:@"%@[%@] (%@:%ld) : %@", kGDTCORConsoleLogger,
-                                 GDTCORMessageCodeEnumToString(code), file, (long)line, format];
+  
   va_list args;
   va_start(args, format);
-  NSLogv(logFormat, args);
+  NSString *message =
+      format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
   va_end(args);
+
+  NSLog(@"%@[%@] (%@:%ld) : %@", kGDTCORConsoleLogger,
+        GDTCORMessageCodeEnumToString(code), file, (long)line, message);
 #endif  // !NDEBUG
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORConsoleLogger.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORConsoleLogger.m
@@ -31,8 +31,7 @@ void GDTCORLog(GDTCORMessageCode code, GDTCORLoggingLevel logLevel, NSString *fo
   if (logLevel >= GDTCORConsoleLoggerLoggingLevel) {
     va_list args;
     va_start(args, format);
-    NSString *message =
-        format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
+    NSString *message = format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
     va_end(args);
 
     NSLog(@"%@[%@] %@", kGDTCORConsoleLogger, GDTCORMessageCodeEnumToString(code), message);
@@ -45,14 +44,13 @@ void GDTCORLogAssert(
 // Don't log anything in not debug builds.
 #if !NDEBUG
   GDTCORMessageCode code = wasFatal ? GDTCORMCEFatalAssertion : GDTCORMCEGeneralError;
-  
+
   va_list args;
   va_start(args, format);
-  NSString *message =
-      format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
+  NSString *message = format ? [[NSString alloc] initWithFormat:format arguments:args] : @"";
   va_end(args);
 
-  NSLog(@"%@[%@] (%@:%ld) : %@", kGDTCORConsoleLogger,
-        GDTCORMessageCodeEnumToString(code), file, (long)line, message);
+  NSLog(@"%@[%@] (%@:%ld) : %@", kGDTCORConsoleLogger, GDTCORMessageCodeEnumToString(code), file,
+        (long)line, message);
 #endif  // !NDEBUG
 }


### PR DESCRIPTION
May fix https://github.com/firebase/firebase-ios-sdk/issues/16455. If not, this fix still makes sense.

When a user's project path contained a % character, the compile-time absolute path __FILE__ macro embedded into the binary also contained a % character. When an assertion triggered in GDTCORPlatform.m, the path was injected unsafely into a format string and passed to NSLogv, causing an EXC_BAD_ACCESS null pointer dereference. 

This PR fixes the issue by pre-formatting the variadic arguments into a message string and safely supplying the formatting parameters directly to NSLog.