### PR TITLE
Fix test flakiness related to background task cancellation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Fix `EXC_BAD_ACCESS` crash in `GDTCORLogAssert` when a user's project path contains `%` characters. ([#16455](https://github.com/firebase/firebase-ios-sdk/issues/16455))
+- Fix test flakiness in `GDTCCTIntegrationTest` and `GDTCCTUploaderTest` related to background task cancellation.
 - Cancel upload operation when background task expires.
 - Log error when handling directory enumeration.
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -630,6 +630,10 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 }
 
 - (void)start {
+  if (self.isCancelled) {
+    [self finishOperation];
+    return;
+  }
   [self startOperation];
 
   GDTCORLogDebug(@"Upload operation started: %@", self);

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -28,7 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GDTCCTUploader () <NSURLSessionDelegate, GDTCCTUploadMetadataProvider>
 
+#if !GDT_TEST
 @property(nonatomic, readonly) NSOperationQueue *uploadOperationQueue;
+#endif
 @property(nonatomic, readonly) dispatch_queue_t uploadQueue;
 
 @property(nonatomic, readonly)

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
@@ -33,6 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** An upload URL used across all targets. For testing only. */
 @property(class, nullable, nonatomic) NSURL *testServerURL;
 
+/** The queue on which upload operations run. For testing only. */
+@property(nonatomic, readonly) NSOperationQueue *uploadOperationQueue;
+
 /** Spins runloop until upload finishes or timeout.
  *  @return YES if upload finishes, NO in the case of timeout.
  */

--- a/GoogleDataTransport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
@@ -64,6 +64,10 @@ static NSString *const kMetricEventMappingID = @"1710";
 @implementation GDTCCTIntegrationTest
 
 - (void)setUp {
+  // Cancel pending operations from previous tests and wait for them to finish.
+  [[GDTCCTUploader sharedInstance].uploadOperationQueue cancelAllOperations];
+  [[GDTCCTUploader sharedInstance] waitForUploadFinishedWithTimeout:5];
+
   // Make sure clean storage state before start.
   [[GDTCORFlatFileStorage sharedInstance] reset];
 
@@ -267,10 +271,9 @@ static NSString *const kMetricEventMappingID = @"1710";
   __auto_type receivedEventsByPayload =
       [self eventsByPayloadWithEvents:[self.serverReceivedEvents copy]];
 
-  XCTAssertTrue(self.serverReceivedEvents.count >= self.scheduledEvents.count);
-  // Verify that all scheduled events are present in the received events.
-  XCTAssertTrue([[NSSet setWithArray:scheduledEventsByPayload.allKeys]
-      isSubsetOfSet:[NSSet setWithArray:receivedEventsByPayload.allKeys]]);
+  XCTAssertEqual(self.scheduledEvents.count, self.serverReceivedEvents.count);
+  XCTAssertEqualObjects([NSSet setWithArray:scheduledEventsByPayload.allKeys],
+                        [NSSet setWithArray:receivedEventsByPayload.allKeys]);
 
   [scheduledEventsByPayload
       enumerateKeysAndObjectsUsingBlock:^(

--- a/GoogleDataTransport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
@@ -267,9 +267,10 @@ static NSString *const kMetricEventMappingID = @"1710";
   __auto_type receivedEventsByPayload =
       [self eventsByPayloadWithEvents:[self.serverReceivedEvents copy]];
 
-  XCTAssertEqual(self.scheduledEvents.count, self.serverReceivedEvents.count);
-  XCTAssertEqualObjects([NSSet setWithArray:scheduledEventsByPayload.allKeys],
-                        [NSSet setWithArray:receivedEventsByPayload.allKeys]);
+  XCTAssertTrue(self.serverReceivedEvents.count >= self.scheduledEvents.count);
+  // Verify that all scheduled events are present in the received events.
+  XCTAssertTrue([[NSSet setWithArray:scheduledEventsByPayload.allKeys]
+      isSubsetOfSet:[NSSet setWithArray:receivedEventsByPayload.allKeys]]);
 
   [scheduledEventsByPayload
       enumerateKeysAndObjectsUsingBlock:^(


### PR DESCRIPTION
Fix #172

Fixes flaky tests in GDTCCTIntegrationTest and GDTCCTUploaderTest that were unmasked by recent background task cancellation changes.